### PR TITLE
Update readme example with better handling of acknowledge event

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ var stream = (new LogicalReplication(connInfo))
 		try {
 			console.log(PluginTestDecoding.parse(log));
 			//TODO: DO SOMETHING. eg) replicate to other dbms(pgsql, mysql, ...)
+			stream.emit('acknowledge', { lsn: lastLsn })
 		} catch (e) {
 			console.trace(log, e);
 		}
@@ -102,6 +103,7 @@ var stream = (new LogicalReplication(connInfo))
 	}, function(err) {
 		if (err) {
 			console.trace('Logical replication initialize error', err);
+			stream.removeAllListeners('acknowledge')
 			setTimeout(proc, 1000);
 		}
 	});


### PR DESCRIPTION
I had to figure this out on my own, but no worries, only a few battle scars later, here is an updated example for the readme.

The first change is to emit the `acknowledge` event (with the last LSN) when there is no error, otherwise, the WAL logs on Postgres not to be cleared, and fill up your hard disk.

The second change removes the `acknowledge` listener on disconnect, otherwise, the number of listeners will pile up and likely cause a memory leak. This fixes issue #4.