### PR TITLE
Adds functionality to pass arbitrary options to replication query.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ stream.getChanges( /*string*/ slotName, /*string*/ uptoLsn, /*object*/ option, /
 - ```option``` can contain any of the following optional properties
     - ```includeXids``` : bool (default: false)
     - ```includeTimestamp``` : bool (default: false)
+	- ```queryOptions``` : object containing decoder specific options (optional)
+		- ```'include-types': false```
+		- ```'filter-tables': 'foo.bar'```
 
 ### 3-2. Method - Stream.stop
 - Stop WAL streaming.

--- a/index.js
+++ b/index.js
@@ -87,6 +87,19 @@ var LogicalReplication = function(config) {
 				'"include-xids" \'' + (option.includeXids === true ? 'on' : 'off') + '\'',
 				'"include-timestamp" \'' + (option.includeTimestamp === true ? 'on' : 'off') + '\'',
 			];
+
+			if (option.queryOptions) {
+				Object.keys(option.queryOptions).forEach(key => {
+					var value = option.queryOptions[key];
+					if (typeof value === 'boolean') {
+						value = value === true ? 'on' : 'off';
+					}
+					opts.push(
+						`"${key}" '${value}'`
+					)
+				})
+			}
+
 			sql += ' (' + (opts.join(' , ')) + ')';
 
 			client.query(sql, function(err) {


### PR DESCRIPTION
When using other decoders for Postgres, many have various options you can pass into the query. This allows a basic interface to allow that.