### PR TITLE
Sends a keepalive message to the database at the specified interval.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ stream.getChanges( /*string*/ slotName, /*string*/ uptoLsn, /*object*/ option, /
 ```
 - ```uptoLsn``` can be null, the minimum value is "0/00000000".
 - ```option``` can contain any of the following optional properties
+	- ```standbyMessageTimeout``` : maximum seconds between keepalive messages (default: 10) 
     - ```includeXids``` : bool (default: false)
     - ```includeTimestamp``` : bool (default: false)
 	- ```queryOptions``` : object containing decoder specific options (optional)


### PR DESCRIPTION
Sends a periodic keepalive message to the server. Without this message, the connection can timeout if no replication events are received.
The timeout can be provided in the `option` parameter passed into the `getChanges` method. The default value is 10 seconds, modeled after the `pg_recvlogical` default (https://github.com/postgres/postgres/blob/9c32e4c35026bd52aaf340bfe7594abc653e42f0/src/bin/pg_basebackup/pg_recvlogical.c#L41). Any value that is falsy or `<= 0` will disable the keepalive.