### PR TITLE
Made options of getChanges optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ var stream = new LogicalReplication({/*config*/});
 stream.getChanges( /*string*/ slotName, /*string*/ uptoLsn, /*object*/ option, /*function(err)*/ initialErrorCallback );
 ```
 - ```uptoLsn``` can be null, the minimum value is "0/00000000".
-- ```option``` can contain any of the following optional properties
+- ```option``` can contain any of the following optional properties; if set to ```undefined``` no options are sent to database
 	- ```standbyMessageTimeout``` : maximum seconds between keepalive messages (default: 10) 
     - ```includeXids``` : bool (default: false)
     - ```includeTimestamp``` : bool (default: false)


### PR DESCRIPTION
I have some output plugins for logical replication that cannot deal with default options (e.g. includeXids). Thus I recommend to make ```options``` in #getChanges optional: In case of ```undefined``` no options are passed to database.