### PR TITLE
Moved includeXids and includeTimestamp to queryOptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ var stream = new LogicalReplication({/*config*/});
 stream.getChanges( /*string*/ slotName, /*string*/ uptoLsn, /*object*/ option, /*function(err)*/ initialErrorCallback );
 ```
 - ```uptoLsn``` can be null, the minimum value is "0/00000000".
-- ```option``` can contain any of the following optional properties
+- ```option``` can contain any of the following optional properties; if set to ```undefined``` no options are sent to database
 	- ```standbyMessageTimeout``` : maximum seconds between keepalive messages (default: 10) 
     - ```includeXids``` : bool (default: false)
     - ```includeTimestamp``` : bool (default: false)

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ var stream = new LogicalReplication({/*config*/});
 stream.getChanges( /*string*/ slotName, /*string*/ uptoLsn, /*object*/ option, /*function(err)*/ initialErrorCallback );
 ```
 - ```uptoLsn``` can be null, the minimum value is "0/00000000".
-- ```option``` can contain any of the following optional properties; if set to ```undefined``` no options are sent to database
+- ```option``` can contain any of the following optional properties
 	- ```standbyMessageTimeout``` : maximum seconds between keepalive messages (default: 10) 
-    - ```includeXids``` : bool (default: false)
-    - ```includeTimestamp``` : bool (default: false)
 	- ```queryOptions``` : object containing decoder specific options (optional)
+		- ```includeXids``` : bool
+		- ```includeTimestamp``` : bool
 		- ```'include-types': false```
 		- ```'filter-tables': 'foo.bar'```
 

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ var LogicalReplication = function(config) {
 	var feedbackCheckInterval;
 	var standbyMessageTimeout;
 
-	this.getChanges = function(slotName, uptoLsn, incomingOption, cb /*(start_err)*/) {
+	this.getChanges = function(slotName, uptoLsn, option, cb /*(start_err)*/) {
 		if (client) {
 			client.removeAllListeners();
 			client.end();

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ var LogicalReplication = function(config) {
 			client.end();
 			client = null;
 		}
-		option = incomingOption || {};
+		option = option || {};
 
 		standbyMessageTimeout = (typeof option.standbyMessageTimeout === 'undefined') ? 10 : option.standbyMessageTimeout;
 
@@ -91,24 +91,21 @@ var LogicalReplication = function(config) {
 
 			var sql = 'START_REPLICATION SLOT ' + slotName + ' LOGICAL ' + (uptoLsn ? uptoLsn : '0/00000000');
 
-			if (incomingOption !== undefined) {
-				var opts = [
-					'"include-xids" \'' + (option.includeXids === true ? 'on' : 'off') + '\'',
-					'"include-timestamp" \'' + (option.includeTimestamp === true ? 'on' : 'off') + '\'',
-				];
+			var opts = [];
 
-				if (option.queryOptions) {
-					Object.keys(option.queryOptions).forEach(key => {
-						var value = option.queryOptions[key];
-						if (typeof value === 'boolean') {
-							value = value === true ? 'on' : 'off';
-						}
-						opts.push(
-							`"${key}" '${value}'`
-						)
-					})
-				}
+			if (option.queryOptions) {
+				Object.keys(option.queryOptions).forEach(key => {
+					var value = option.queryOptions[key];
+					if (typeof value === 'boolean') {
+						value = value === true ? 'on' : 'off';
+					}
+					opts.push(
+						`"${key}" '${value}'`
+					)
+				})
+			}
 
+			if (opts.length > 0) {
 				sql += ' (' + (opts.join(' , ')) + ')';
 			}
 


### PR DESCRIPTION
I found out that there are logical decoder plugins that do not work with includeXids or includeTimestamp. Thus, I recommend to move both options to queryOptions to be able to use them optionally. However, this might be a breaking change.