### PR TITLE
Add `pgoutput` plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 /dist/
 /junit.xml
+/coverage/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 - [PostgreSQL Logical Replication](https://www.postgresql.org/docs/current/logical-replication.html) client for node.js
 - Supported plugins
     - [wal2json](https://github.com/eulerto/wal2json) (Recommended)
+    - [pgoutput](https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html) (Native to PostgreSQL)
     - [decoderbufs](https://github.com/debezium/postgres-decoderbufs)
     - [test_decoding](https://www.postgresql.org/docs/current/test-decoding.html) (Not recommended)
 - [Document for old version(1.x)](https://github.com/kibae/pg-logical-replication/blob/master/README-1.x.md)

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "rdbms",
     "replication",
     "logical",
+    "logical-decoding",
     "logical-replication",
     "cdc",
     "wal2json",
+    "pgoutput",
     "decoderbufs",
     "typescript",
     "nodejs"

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ export * from './logical-replication-service';
 
 export * from './output-plugins/test_decoding/test-decoding-plugin';
 
+export * from './output-plugins/pgoutput';
+
 export * from './output-plugins/wal2json/wal2json-plugin';
 export * from './output-plugins/wal2json/wal2json-plugin-options.type';
 export * from './output-plugins/wal2json/wal2json-plugin-output.type';

--- a/src/output-plugins/pgoutput/binary-reader.ts
+++ b/src/output-plugins/pgoutput/binary-reader.ts
@@ -1,0 +1,95 @@
+import { TextDecoder } from 'util'
+
+// should not use { fatal: true } because ErrorResponse can use invalid utf8 chars
+const textDecoder = new TextDecoder()
+
+// https://www.postgresql.org/docs/14/protocol-message-types.html
+export class BinaryReader {
+  _p = 0
+  constructor(private _b: Uint8Array) {}
+
+  readUint8() {
+    this.checkSize(1)
+
+    return this._b[this._p++]
+  }
+
+  readInt16() {
+    this.checkSize(2)
+
+    return (this._b[this._p++] << 8) | this._b[this._p++]
+  }
+
+  readInt32() {
+    this.checkSize(4)
+
+    return (
+      (this._b[this._p++] << 24) |
+      (this._b[this._p++] << 16) |
+      (this._b[this._p++] << 8) |
+      this._b[this._p++]
+    )
+  }
+
+  readString() {
+    const endIdx = this._b.indexOf(0x00, this._p)
+
+    if (endIdx < 0) {
+      // TODO PgError.protocol_violation
+      throw Error('unexpected end of message')
+    }
+
+    const strBuf = this._b.subarray(this._p, endIdx)
+    this._p = endIdx + 1
+
+    return this.decodeText(strBuf)
+  }
+
+  decodeText(strBuf: Uint8Array) {
+    return textDecoder.decode(strBuf)
+  }
+
+  read(n: number) {
+    this.checkSize(n)
+
+    return this._b.subarray(this._p, (this._p += n))
+  }
+
+  checkSize(n: number) {
+    if (this._b.length < this._p + n) {
+      // TODO PgError.protocol_violation
+      throw Error('unexpected end of message')
+    }
+  }
+
+  array<T>(length: number, fn: () => T): T[] {
+    return Array.from({ length }, fn, this)
+  }
+
+  // replication helpers
+  readLsn() {
+    const h = this.readUint32()
+    const l = this.readUint32()
+
+    if (h === 0 && l === 0) {
+      return null
+    }
+
+    return `${h.toString(16).padStart(8, '0')}/${l
+      .toString(16)
+      .padStart(8, '0')}`.toUpperCase()
+  }
+
+  readTime() {
+    // (POSTGRES_EPOCH_JDATE - UNIX_EPOCH_JDATE) * USECS_PER_DAY == 946684800000000
+    return this.readUint64() + BigInt('946684800000000')
+  }
+
+  readUint64() {
+    return (BigInt(this.readUint32()) << BigInt(32)) | BigInt(this.readUint32())
+  }
+
+  readUint32() {
+    return this.readInt32() >>> 0
+  }
+}

--- a/src/output-plugins/pgoutput/index.ts
+++ b/src/output-plugins/pgoutput/index.ts
@@ -1,0 +1,3 @@
+
+export * from './pgoutput.plugin'
+export * as Pgoutput from './pgoutput.types'

--- a/src/output-plugins/pgoutput/pgoutput-parser.ts
+++ b/src/output-plugins/pgoutput/pgoutput-parser.ts
@@ -1,0 +1,310 @@
+// https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html
+import { types } from 'pg'
+
+import { BinaryReader } from './binary-reader'
+import {
+  Message,
+  MessageBegin,
+  MessageCommit,
+  MessageDelete,
+  MessageInsert,
+  MessageMessage,
+  MessageOrigin,
+  MessageRelation,
+  MessageTruncate,
+  MessageType,
+  MessageUpdate,
+  RelationColumn,
+} from './pgoutput.types'
+
+export class PgoutputParser {
+  _typeCache = new Map<number, { typeSchema: string; typeName: string }>()
+  _relationCache = new Map<number, MessageRelation>()
+
+  public parse(buf: Buffer): Message {
+    const reader = new BinaryReader(buf)
+    const tag = reader.readUint8()
+
+    switch (tag) {
+      case 0x42 /*B*/:
+        return this.msgBegin(reader)
+      case 0x4f /*O*/:
+        return this.msgOrigin(reader)
+      case 0x59 /*Y*/:
+        return this.msgType(reader)
+      case 0x52 /*R*/:
+        return this.msgRelation(reader)
+      case 0x49 /*I*/:
+        return this.msgInsert(reader)
+      case 0x55 /*U*/:
+        return this.msgUpdate(reader)
+      case 0x44 /*D*/:
+        return this.msgDelete(reader)
+      case 0x54 /*T*/:
+        return this.msgTruncate(reader)
+      case 0x4d /*M*/:
+        return this.msgMessage(reader)
+      case 0x43 /*C*/:
+        return this.msgCommit(reader)
+      default:
+        throw Error('unknown pgoutput message')
+    }
+  }
+
+  private msgBegin(reader: BinaryReader): MessageBegin {
+    // TODO lsn can be null if origin sended
+    // https://github.com/postgres/postgres/blob/85c61ba8920ba73500e1518c63795982ee455d14/src/backend/replication/pgoutput/pgoutput.c#L409
+    // https://github.com/postgres/postgres/blob/27b77ecf9f4d5be211900eda54d8155ada50d696/src/include/replication/reorderbuffer.h#L275
+
+    return {
+      tag: 'begin',
+      commitLsn: reader.readLsn(),
+      commitTime: reader.readTime(),
+      xid: reader.readInt32(),
+    }
+  }
+
+  private msgOrigin(reader: BinaryReader): MessageOrigin {
+    return {
+      tag: 'origin',
+      originLsn: reader.readLsn(),
+      originName: reader.readString(),
+    }
+  }
+
+  private msgType(reader: BinaryReader): MessageType {
+    const typeOid = reader.readInt32()
+    const typeSchema = reader.readString()
+    const typeName = reader.readString()
+
+    // mem leak not likely to happen because amount of types is usually small
+    this._typeCache.set(typeOid, { typeSchema, typeName })
+
+    return { tag: 'type', typeOid, typeSchema, typeName }
+  }
+
+  private msgRelation(reader: BinaryReader): MessageRelation {
+    // lsn expected to be null
+    // https://github.com/postgres/postgres/blob/27b77ecf9f4d5be211900eda54d8155ada50d696/src/backend/replication/walsender.c#L1342
+    const relationOid = reader.readInt32()
+    const schema = reader.readString()
+    const name = reader.readString()
+    const replicaIdentity = this.readRelationReplicaIdentity(reader)
+    const columns = reader.array(reader.readInt16(), () =>
+      this.readRelationColumn(reader)
+    )
+    const keyColumns = columns.filter(it => it.flags & 0b1).map(it => it.name)
+
+    const msg: MessageRelation = {
+      tag: 'relation',
+      relationOid,
+      schema,
+      name,
+      replicaIdentity,
+      columns,
+      keyColumns,
+    }
+
+    // mem leak not likely to happen because amount of relations is usually small
+    this._relationCache.set(relationOid, msg)
+
+    return msg
+  }
+
+  private readRelationReplicaIdentity(reader: BinaryReader) {
+    // https://www.postgresql.org/docs/14/catalog-pg-class.html
+    const ident = reader.readUint8()
+
+    switch (ident) {
+      case 0x64 /*d*/:
+        return 'default'
+      case 0x6e /*n*/:
+        return 'nothing'
+      case 0x66 /*f*/:
+        return 'full'
+      case 0x69 /*i*/:
+        return 'index'
+      default:
+        throw Error(`unknown replica identity ${String.fromCharCode(ident)}`)
+    }
+  }
+
+  private readRelationColumn(reader: BinaryReader): RelationColumn {
+    const flags = reader.readUint8()
+    const name = reader.readString()
+    const typeOid = reader.readInt32()
+    const typeMod = reader.readInt32()
+
+    return {
+      flags,
+      name,
+      typeOid,
+      typeMod,
+      typeSchema: null,
+      typeName: null, // TODO resolve builtin type names?
+      ...this._typeCache.get(typeOid),
+      parser: types.getTypeParser(typeOid),
+    }
+  }
+
+  private msgInsert(reader: BinaryReader): MessageInsert {
+    const relation = this._relationCache.get(reader.readInt32())
+
+    if (!relation) {
+      throw Error('missing relation')
+    }
+
+    reader.readUint8() // consume the 'N' key
+
+    return {
+      tag: 'insert',
+      relation,
+      new: this.readTuple(reader, relation),
+    }
+  }
+
+  private msgUpdate(reader: BinaryReader): MessageUpdate {
+    const relation = this._relationCache.get(reader.readInt32())
+
+    if (!relation) {
+      throw Error('missing relation')
+    }
+
+    let key: Record<string, any> | null = null
+    let old: Record<string, any> | null = null
+    let new_: Record<string, any> | null = null
+    const subMsgKey = reader.readUint8()
+
+    if (subMsgKey === 0x4b /*K*/) {
+      key = this.readKeyTuple(reader, relation)
+      reader.readUint8() // consume the 'N' key
+      new_ = this.readTuple(reader, relation)
+    } else if (subMsgKey === 0x4f /*O*/) {
+      old = this.readTuple(reader, relation)
+      reader.readUint8() // consume the 'N' key
+      new_ = this.readTuple(reader, relation, old)
+    } else if (subMsgKey === 0x4e /*N*/) {
+      new_ = this.readTuple(reader, relation)
+    } else {
+      throw Error(`unknown submessage key ${String.fromCharCode(subMsgKey)}`)
+    }
+
+    return { tag: 'update', relation, key, old, new: new_ }
+  }
+
+  private msgDelete(reader: BinaryReader): MessageDelete {
+    const relation = this._relationCache.get(reader.readInt32())
+
+    if (!relation) {
+      throw Error('missing relation')
+    }
+
+    let key: Record<string, any> | null = null
+    let old: Record<string, any> | null = null
+    const subMsgKey = reader.readUint8()
+
+    if (subMsgKey === 0x4b /*K*/) {
+      key = this.readKeyTuple(reader, relation)
+    } else if (subMsgKey === 0x4f /*O*/) {
+      old = this.readTuple(reader, relation)
+    } else {
+      throw Error(`unknown submessage key ${String.fromCharCode(subMsgKey)}`)
+    }
+
+    return { tag: 'delete', relation, key, old }
+  }
+
+  private readKeyTuple(reader: BinaryReader, relation: MessageRelation): Record<string, any> {
+    const tuple = this.readTuple(reader, relation)
+    const key = Object.create(null)
+
+    for (const k of relation.keyColumns) {
+      // If value is `null`, then it is definitely not part of key,
+      // because key cannot have nulls by documentation.
+      // And if we got `null` while reading keyOnly tuple,
+      // then it means that `null` is not actual value
+      // but placeholder of non-key column.
+      key[k] = tuple[k] === null ? undefined : tuple[k]
+    }
+
+    return key
+  }
+
+  private readTuple(
+    reader: BinaryReader,
+    { columns }: MessageRelation,
+    unchangedToastFallback?: Record<string, any> | null
+  ): Record<string, any> {
+    const nfields = reader.readInt16()
+    const tuple = Object.create(null)
+
+    for (let i = 0; i < nfields; i++) {
+      const { name, parser } = columns[i]
+      const kind = reader.readUint8()
+
+      switch (kind) {
+        case 0x62: // 'b' binary
+          const bsize = reader.readInt32()
+          const bval = reader.read(bsize)
+          // dont need to .slice() because new buffer
+          // is created for each replication chunk
+          tuple[name] = bval
+          break
+        case 0x74: // 't' text
+          const valsize = reader.readInt32()
+          const valbuf = reader.read(valsize)
+          const valtext = reader.decodeText(valbuf)
+          tuple[name] = parser(valtext)
+          break
+        case 0x6e: // 'n' null
+          tuple[name] = null
+          break
+        case 0x75: // 'u' unchanged toast datum
+          tuple[name] = unchangedToastFallback?.[name]
+          break
+        default:
+          throw Error(`unknown attribute kind ${String.fromCharCode(kind)}`)
+      }
+    }
+
+    return tuple
+  }
+
+  private msgTruncate(reader: BinaryReader): MessageTruncate {
+    const nrels = reader.readInt32()
+    const flags = reader.readUint8()
+
+    return {
+      tag: 'truncate',
+      cascade: Boolean(flags & 0b1),
+      restartIdentity: Boolean(flags & 0b10),
+      relations: reader.array(
+        nrels,
+        () => this._relationCache.get(reader.readInt32()) as MessageRelation
+      ),
+    }
+  }
+
+  private msgMessage(reader: BinaryReader): MessageMessage {
+    const flags = reader.readUint8()
+
+    return {
+      tag: 'message',
+      flags,
+      transactional: Boolean(flags & 0b1),
+      messageLsn: reader.readLsn(),
+      prefix: reader.readString(),
+      content: reader.read(reader.readInt32()),
+    }
+  }
+
+  private msgCommit(reader: BinaryReader): MessageCommit {
+    return {
+      tag: 'commit',
+      flags: reader.readUint8(), // reserved unused
+      commitLsn: reader.readLsn(), // should be the same as begin.commitLsn
+      commitEndLsn: reader.readLsn(),
+      commitTime: reader.readTime(),
+    }
+  }
+}

--- a/src/output-plugins/pgoutput/pgoutput.plugin.ts
+++ b/src/output-plugins/pgoutput/pgoutput.plugin.ts
@@ -1,0 +1,34 @@
+import { Client } from 'pg'
+
+import { AbstractPlugin } from '../abstract.plugin'
+import { Message, Options } from './pgoutput.types'
+import { PgoutputParser } from './pgoutput-parser'
+
+export class PgoutputPlugin extends AbstractPlugin<Options> {
+  private parser: PgoutputParser
+
+  constructor(options: Options) {
+    super(options)
+
+    this.parser = new PgoutputParser()
+  }
+
+  get name(): string {
+    return 'pgoutput'
+  }
+
+  parse(buffer: Buffer): Message {
+    return this.parser.parse(buffer)
+  }
+
+  start(client: Client, slotName: string, lastLsn: string): Promise<any> {
+    const options = [
+      `proto_version '${this.options.protoVersion}'`,
+      `publication_names '${this.options.publicationNames.join(',')}'`,
+    ].join(', ')
+
+    const sql = `START_REPLICATION SLOT "${slotName}" LOGICAL ${lastLsn} (${options})`
+
+    return client.query(sql)
+  }
+}

--- a/src/output-plugins/pgoutput/pgoutput.types.ts
+++ b/src/output-plugins/pgoutput/pgoutput.types.ts
@@ -1,0 +1,102 @@
+// https://www.postgresql.org/docs/current/protocol-logical-replication.html#PROTOCOL-LOGICAL-REPLICATION-PARAMS
+export interface Options {
+  protoVersion: 1 | 2
+  publicationNames: string[]
+}
+
+export type Message =
+  | MessageBegin
+  | MessageCommit
+  | MessageDelete
+  | MessageInsert
+  | MessageMessage
+  | MessageOrigin
+  | MessageRelation
+  | MessageTruncate
+  | MessageType
+  | MessageUpdate
+
+export interface MessageBegin {
+  tag: 'begin'
+  commitLsn: string | null
+  commitTime: BigInt
+  xid: number
+}
+
+export interface MessageCommit {
+  tag: 'commit'
+  flags: number
+  commitLsn: string | null
+  commitEndLsn: string | null
+  commitTime: BigInt
+}
+
+export interface MessageDelete {
+  tag: 'delete'
+  relation: MessageRelation
+  key: Record<string, any> | null
+  old: Record<string, any> | null
+}
+
+export interface MessageInsert {
+  tag: 'insert'
+  relation: MessageRelation
+  new: Record<string, any>
+}
+
+export interface MessageMessage {
+  tag: 'message'
+  flags: number
+  transactional: boolean
+  messageLsn: string | null
+  prefix: string
+  content: Uint8Array
+}
+
+export interface MessageOrigin {
+  tag: 'origin'
+  originLsn: string | null
+  originName: string
+}
+
+export interface MessageRelation {
+  tag: 'relation'
+  relationOid: number
+  schema: string
+  name: string
+  replicaIdentity: 'default' | 'nothing' | 'full' | 'index'
+  columns: RelationColumn[]
+  keyColumns: string[]
+}
+
+export interface RelationColumn {
+  name: string
+  flags: number
+  typeOid: number
+  typeMod: number
+  typeSchema: string | null
+  typeName: string | null
+  parser: (raw: any) => any
+}
+
+export interface MessageTruncate {
+  tag: 'truncate'
+  cascade: boolean
+  restartIdentity: boolean
+  relations: MessageRelation[]
+}
+
+export interface MessageType {
+  tag: 'type'
+  typeOid: number
+  typeSchema: string
+  typeName: string
+}
+
+export interface MessageUpdate {
+  tag: 'update'
+  relation: MessageRelation
+  key: Record<string, any> | null
+  old: Record<string, any> | null
+  new: Record<string, any>
+}

--- a/src/test/decoder-pgoutput.spec.ts
+++ b/src/test/decoder-pgoutput.spec.ts
@@ -1,0 +1,228 @@
+import { Client } from 'pg';
+import { LogicalReplicationService } from '../';
+import { TestClientConfig } from './client-config';
+
+import { PgoutputPlugin, Pgoutput } from '../output-plugins/pgoutput';
+
+jest.setTimeout(10_000);
+const slotName = 'pgoutput_test_slot';
+const publicationName = 'pgoutput_test_pub';
+const decoderName = 'pgoutput';
+
+const lsnRe = /^[0-9A-F]{8}\/[0-9A-F]{8}$/;
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+let client: Client;
+
+describe('pgoutput', () => {
+  beforeAll(async () => {
+    client = new Client({ ...TestClientConfig });
+    await client.connect();
+
+    await client
+      .query(
+        //language=sql
+        `SELECT *
+         FROM pg_create_logical_replication_slot('${slotName}', '${decoderName}');
+        CREATE PUBLICATION "${publicationName}" FOR ALL TABLES;`
+      )
+      .catch((e) => {});
+  });
+
+  afterAll(async () => {
+    await client
+      .query(
+        //language=sql
+        `SELECT pg_drop_replication_slot('${slotName}');
+        DROP PUBLICATION "${publicationName}";`
+      )
+      .catch((e) => {});
+    await client.end();
+  });
+
+  it('Insert, Delete(w/FK)', async () => {
+    const service = new LogicalReplicationService(TestClientConfig);
+    const plugin = new PgoutputPlugin({ protoVersion: 1, publicationNames: [publicationName] });
+    const messages: Pgoutput.Message[] = [];
+
+    service.on('data', (lsn: string, log: Pgoutput.Message) => {
+      messages.push(log);
+    });
+
+    service.subscribe(plugin, slotName).catch((e) => {
+      console.error('Error from .subscribe', e);
+    });
+
+    await sleep(100);
+
+    // insert
+    const result = await client.query(
+      //language=sql
+      `INSERT INTO users(firstname, lastname, email, phone)
+           SELECT md5(RANDOM()::TEXT), md5(RANDOM()::TEXT), md5(RANDOM()::TEXT), md5(RANDOM()::TEXT)
+           FROM generate_series(1, 5)
+           RETURNING *`
+    );
+    expect(result.rowCount).toBe(5);
+
+    // insert child
+    expect(
+      (
+        await client.query(
+          //language=sql
+          `INSERT INTO user_contents(user_id, title, body)
+       SELECT id, md5(RANDOM()::TEXT), md5(RANDOM()::TEXT) FROM users WHERE id >= ${result.rows[0].id}`
+        )
+      ).rowCount
+    ).toBe(5);
+
+    await sleep(1000);
+
+    const begin = messages.find((msg) => msg.tag === 'begin');
+    expect(begin).toStrictEqual({
+      tag: 'begin',
+      commitLsn: expect.stringMatching(lsnRe),
+      commitTime: expect.any(BigInt),
+      xid: expect.any(Number),
+    });
+
+    const commit = messages.find((msg) => msg.tag === 'commit');
+    expect(commit).toStrictEqual({
+      tag: 'commit',
+      flags: 0,
+      commitLsn: expect.stringMatching(lsnRe),
+      commitEndLsn: expect.stringMatching(lsnRe),
+      commitTime: expect.any(BigInt),
+    });
+
+    const inserts = messages.filter((msg) => msg.tag === 'insert');
+    expect(inserts.length).toBe(10);
+
+    expect(inserts[0]).toEqual({
+      tag: 'insert',
+      relation: {
+        tag: 'relation',
+        schema: 'public',
+        name: 'users',
+        relationOid: expect.any(Number),
+        replicaIdentity: 'default',
+        columns: expect.any(Array),
+        keyColumns: ['id'],
+      },
+      new: {
+        id: expect.any(String),
+        firstname: expect.any(String),
+        lastname: expect.any(String),
+        email: expect.any(String),
+        phone: expect.any(String),
+        deleted: expect.any(Boolean),
+        created: expect.any(Date),
+      },
+    });
+
+    // delete
+    expect(
+      (
+        await client.query(
+          //language=sql
+          `DELETE FROM users WHERE id >= ${result.rows[0].id}`
+        )
+      ).rowCount
+    ).toBe(5);
+
+    await sleep(1000);
+
+    const deletes = messages.filter((msg) => msg.tag === 'delete');
+    // because of the cascade delete, we expect users 5 rows + user_contents 5 rows
+    expect(deletes.length).toBe(10);
+
+    expect(deletes[0]).toEqual({
+      tag: 'delete',
+      relation: {
+        tag: 'relation',
+        schema: 'public',
+        name: 'users',
+        relationOid: expect.any(Number),
+        replicaIdentity: 'default',
+        columns: expect.any(Array),
+        keyColumns: ['id'],
+      },
+      key: { id: expect.any(String) },
+      old: null, // only provided when REPLICA IDENTITY set to FULL
+    });
+
+    expect(deletes[9]).toEqual({
+      tag: 'delete',
+      relation: {
+        tag: 'relation',
+        schema: 'public',
+        name: 'user_contents',
+        relationOid: expect.any(Number),
+        replicaIdentity: 'default',
+        columns: expect.any(Array),
+        keyColumns: ['id'],
+      },
+      key: { id: expect.any(String) },
+      old: null,
+    });
+
+    await service.stop();
+  });
+
+  it('Update', async () => {
+    const service = new LogicalReplicationService(TestClientConfig);
+    const plugin = new PgoutputPlugin({ protoVersion: 1, publicationNames: [publicationName] });
+    const messages: Pgoutput.Message[] = [];
+
+    service.on('data', (lsn: string, log: Pgoutput.Message) => {
+      messages.push(log);
+    });
+
+    service.subscribe(plugin, slotName).catch((e) => {
+      console.error('Error from .subscribe', e);
+    });
+
+    await sleep(100);
+
+    expect(
+      (
+        await client.query(
+          //language=sql
+          `UPDATE users
+           SET firstname = md5(RANDOM()::TEXT)
+           WHERE id BETWEEN 1 AND 10`
+        )
+      ).rowCount
+    ).toBe(10);
+
+    await sleep(1000);
+
+    const updates = messages.filter((msg) => msg.tag === 'update');
+    expect(updates.length).toBe(10);
+
+    expect(updates[0]).toEqual({
+      tag: 'update',
+      relation: {
+        tag: 'relation',
+        schema: 'public',
+        name: 'users',
+        relationOid: expect.any(Number),
+        replicaIdentity: 'default',
+        columns: expect.any(Array),
+        keyColumns: ['id'],
+      },
+      key: null,
+      old: null, // only provided when REPLICA IDENTITY set to FULL
+      new: {
+        id: expect.any(String),
+        firstname: expect.any(String),
+        lastname: expect.any(String),
+        email: expect.any(String),
+        phone: expect.any(String),
+        deleted: expect.any(Boolean),
+        created: expect.any(Date),
+      },
+    });
+
+    await service.stop();
+  });
+});


### PR DESCRIPTION
Allows consuming logical replication from the built-in plugin from psql (other than `test_decoding`).

The parser and binary reader borrow heavily from [`pgwire`](https://github.com/kagis/pgwire/blob/44c0f1d18f1c1feee2e6efe3b300feea18f0d71e/mod.js).