### PR TITLE
fix: build settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "pg-logical-replication",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pg-logical-replication",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "eventemitter2": "^6.4.7",
-        "pg": "^8.7.0"
+        "eventemitter2": ">=6.4.0",
+        "pg": ">=6.2.2"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",
+        "@types/node": "^14.14.31",
         "@types/pg": "^8.6.5",
         "jest": "^28.1.3",
         "jest-junit": "^14.0.0",
@@ -24,10 +25,7 @@
         "typescript": "^4.7.4"
       },
       "engines": {
-        "node": ">= 16.0.0"
-      },
-      "peerDependencies": {
-        "pg": "^8.7.0"
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1169,9 +1167,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
-      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
+      "version": "14.18.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
+      "integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A==",
       "dev": true
     },
     "node_modules/@types/pg": {
@@ -4936,9 +4934,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
-      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
+      "version": "14.18.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
+      "integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A==",
       "dev": true
     },
     "@types/pg": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   ],
   "devDependencies": {
     "@types/jest": "^28.1.6",
+    "@types/node": "^14.14.31",
     "@types/pg": "^8.6.5",
     "jest": "^28.1.3",
     "jest-junit": "^14.0.0",
@@ -76,10 +77,6 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "eventemitter2": ">=6.4.0",
-    "pg": ">=6.2.2"
-  },
-  "peerDependencies": {
     "eventemitter2": ">=6.4.0",
     "pg": ">=6.2.2"
   },

--- a/src/output-plugins/decoderbufs/decoderbufs-plugin.ts
+++ b/src/output-plugins/decoderbufs/decoderbufs-plugin.ts
@@ -1,8 +1,6 @@
 import { AbstractPlugin } from '../abstract.plugin';
 import { Client } from 'pg';
-
-// https://github.com/debezium/postgres-decoderbufs/blob/main/proto/pg_logicaldec.proto
-const decoderbufsProto = require('./pg_logicaldec.proto.json');
+import decoderbufsProto from './pg_logicaldec.proto';
 
 export interface ProtocolBuffersPluginOptions {}
 

--- a/src/output-plugins/decoderbufs/pg_logicaldec.proto.ts
+++ b/src/output-plugins/decoderbufs/pg_logicaldec.proto.ts
@@ -1,4 +1,5 @@
-{
+// https://github.com/debezium/postgres-decoderbufs/blob/main/proto/pg_logicaldec.proto
+export default {
   "nested": {
     "decoderbufs": {
       "options": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,9 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es6",
+    "target": "ES2020", // https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping#node-14
     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["ES2020"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     "experimentalDecorators": true,
     /* Enable experimental support for TC39 stage 2 draft decorators. */


### PR DESCRIPTION
- 2.0.1 has a bug in the published copy which produces the following error: 
  "Error: Cannot find module './pg_logicaldec.proto.json'" 
  Caused by `tsc` not copying the proto.json file to the `./dist` dir during the build step. 
  The easy way to fix this is to just make the file a `.ts` file instead of a `.json` file.

- Updated the `tsc` target to ES2020, which correlates to the [max target usable on Node 14](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping#node-14).
- Removed the two peer dependencies as they are required prod dependencies already.