### PR TITLE
fix: heartbeat shouldRespond as bool

### DIFF
--- a/src/logical-replication-service.ts
+++ b/src/logical-replication-service.ts
@@ -125,7 +125,7 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
           const timestamp = Math.floor(
             buffer.readUInt32BE(9) * 4294967.296 + buffer.readUInt32BE(13) / 1000 + 946080000000
           );
-          const shouldRespond = buffer.readInt8(17);
+          const shouldRespond = !!buffer.readInt8(17);
           this.emit('heartbeat', lsn, timestamp, shouldRespond);
         }
         this._lastLsn = lsn;

--- a/src/test/decoder-pgoutput.spec.ts
+++ b/src/test/decoder-pgoutput.spec.ts
@@ -236,6 +236,9 @@ describe('pgoutput', () => {
     });
     // setInterval(() => console.log(`Updated: ${rowCount}`), 1000);
 
+    const heartbeatCb = jest.fn()
+    service.on('heartbeat', heartbeatCb);
+
     (function proc() {
       service.subscribe(plugin, slotName).catch((e) => {
         console.error(e);
@@ -269,6 +272,11 @@ describe('pgoutput', () => {
     }
 
     expect(rowCount).toBe(count);
+    expect(heartbeatCb).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Number),
+      expect.any(Boolean)
+    )
 
     await service.stop();
   });


### PR DESCRIPTION
The `shouldRespond` flag provided to the `heartbeat` event should be boolean, but was being passed as the raw int read from the buffer. Note, the types were already, correctly set to a boolean.