### PR TITLE
chore: Use fully qualified paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,9 @@
       "jest-junit"
     ],
     "maxConcurrency": 1,
-    "maxWorkers": 1
+    "maxWorkers": 1,
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
-export * from './logical-replication-service';
+export * from './logical-replication-service.js';
 
-export * from './output-plugins/test_decoding/test-decoding-plugin';
+export * from './output-plugins/test_decoding/test-decoding-plugin.js';
 
-export * from './output-plugins/pgoutput';
+export * from './output-plugins/pgoutput/index.js';
 
-export * from './output-plugins/wal2json/wal2json-plugin';
-export * from './output-plugins/wal2json/wal2json-plugin-options.type';
-export * from './output-plugins/wal2json/wal2json-plugin-output.type';
+export * from './output-plugins/wal2json/wal2json-plugin-options.type.js';
+export * from './output-plugins/wal2json/wal2json-plugin-output.type.js';
+export * from './output-plugins/wal2json/wal2json-plugin.js';
 
-export * from './output-plugins/decoderbufs/decoderbufs-plugin';
-export * from './output-plugins/decoderbufs/decoderbufs-plugin-output.type';
+export * from './output-plugins/decoderbufs/decoderbufs-plugin-output.type.js';
+export * from './output-plugins/decoderbufs/decoderbufs-plugin.js';
+

--- a/src/logical-replication-service.ts
+++ b/src/logical-replication-service.ts
@@ -1,6 +1,6 @@
 import EventEmitter2 from 'eventemitter2';
 import { Client, ClientConfig, Connection } from 'pg';
-import { AbstractPlugin } from './output-plugins/abstract.plugin';
+import { AbstractPlugin } from './output-plugins/abstract.plugin.js';
 
 export interface ReplicationClientConfig extends ClientConfig {
   replication: 'database';

--- a/src/output-plugins/decoderbufs/decoderbufs-plugin.ts
+++ b/src/output-plugins/decoderbufs/decoderbufs-plugin.ts
@@ -1,6 +1,6 @@
-import { AbstractPlugin } from '../abstract.plugin';
 import { Client } from 'pg';
-import decoderbufsProto from './pg_logicaldec.proto';
+import { AbstractPlugin } from '../abstract.plugin.js';
+import decoderbufsProto from './pg_logicaldec.proto.js';
 
 export interface ProtocolBuffersPluginOptions {}
 

--- a/src/output-plugins/pgoutput/index.ts
+++ b/src/output-plugins/pgoutput/index.ts
@@ -1,2 +1,3 @@
-export * from './pgoutput-plugin';
-export * as Pgoutput from './pgoutput.types';
+export * from './pgoutput-plugin.js';
+export * as Pgoutput from './pgoutput.types.js';
+

--- a/src/output-plugins/pgoutput/pgoutput-parser.ts
+++ b/src/output-plugins/pgoutput/pgoutput-parser.ts
@@ -1,7 +1,7 @@
 // https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html
 import { types } from 'pg';
 
-import { BinaryReader } from './binary-reader';
+import { BinaryReader } from './binary-reader.js';
 import {
   Message,
   MessageBegin,
@@ -15,7 +15,7 @@ import {
   MessageType,
   MessageUpdate,
   RelationColumn,
-} from './pgoutput.types';
+} from './pgoutput.types.js';
 
 export class PgoutputParser {
   _typeCache = new Map<number, { typeSchema: string; typeName: string }>();

--- a/src/output-plugins/pgoutput/pgoutput-plugin.ts
+++ b/src/output-plugins/pgoutput/pgoutput-plugin.ts
@@ -1,8 +1,8 @@
 import { Client } from 'pg';
 
-import { AbstractPlugin } from '../abstract.plugin';
-import { Message, Options } from './pgoutput.types';
-import { PgoutputParser } from './pgoutput-parser';
+import { AbstractPlugin } from '../abstract.plugin.js';
+import { PgoutputParser } from './pgoutput-parser.js';
+import { Message, Options } from './pgoutput.types.js';
 
 export class PgoutputPlugin extends AbstractPlugin<Options> {
   private parser: PgoutputParser;

--- a/src/output-plugins/test_decoding/test-decoding-plugin.ts
+++ b/src/output-plugins/test_decoding/test-decoding-plugin.ts
@@ -1,5 +1,5 @@
-import { AbstractPlugin } from '../abstract.plugin';
 import { Client } from 'pg';
+import { AbstractPlugin } from '../abstract.plugin.js';
 
 const decoder = require('./decoder');
 

--- a/src/output-plugins/wal2json/wal2json-plugin.ts
+++ b/src/output-plugins/wal2json/wal2json-plugin.ts
@@ -1,6 +1,6 @@
-import { AbstractPlugin } from '../abstract.plugin';
 import { Client } from 'pg';
-import { StringOptionKeys, Wal2JsonPluginOptions } from './wal2json-plugin-options.type';
+import { AbstractPlugin } from '../abstract.plugin.js';
+import { StringOptionKeys, Wal2JsonPluginOptions } from './wal2json-plugin-options.type.js';
 
 /**
  * wal2json

--- a/src/test/acknowledge.spec.ts
+++ b/src/test/acknowledge.spec.ts
@@ -1,11 +1,11 @@
 /*
 SELECT * FROM pg_create_logical_replication_slot('slot_decoderbufs', 'decoderbufs');
 */
-import { LogicalReplicationService } from '../logical-replication-service';
-import { TestClientConfig } from './client-config';
-import { sleep, TestClient } from './test-common';
-import { Wal2JsonPlugin } from '../output-plugins/wal2json/wal2json-plugin';
-import { Wal2Json } from '../output-plugins/wal2json/wal2json-plugin-output.type';
+import { LogicalReplicationService } from '../logical-replication-service.js';
+import { Wal2Json } from '../output-plugins/wal2json/wal2json-plugin-output.type.js';
+import { Wal2JsonPlugin } from '../output-plugins/wal2json/wal2json-plugin.js';
+import { TestClientConfig } from './client-config.js';
+import { sleep, TestClient } from './test-common.js';
 
 jest.setTimeout(1000 * 10);
 const [slotName, decoderName] = ['slot_acknowledge', 'wal2json'];

--- a/src/test/decoder-decoderbufs.spec.ts
+++ b/src/test/decoder-decoderbufs.spec.ts
@@ -1,14 +1,14 @@
 /*
 SELECT * FROM pg_create_logical_replication_slot('slot_decoderbufs', 'decoderbufs');
 */
-import { LogicalReplicationService } from '../logical-replication-service';
-import { TestClientConfig } from './client-config';
-import { ProtocolBuffersPlugin } from '../output-plugins/decoderbufs/decoderbufs-plugin';
+import { LogicalReplicationService } from '../logical-replication-service.js';
 import {
   ProtocolBuffers,
   ProtocolBuffersOperation,
-} from '../output-plugins/decoderbufs/decoderbufs-plugin-output.type';
-import { sleep, TestClient } from './test-common';
+} from '../output-plugins/decoderbufs/decoderbufs-plugin-output.type.js';
+import { ProtocolBuffersPlugin } from '../output-plugins/decoderbufs/decoderbufs-plugin.js';
+import { TestClientConfig } from './client-config.js';
+import { TestClient, sleep } from './test-common.js';
 
 jest.setTimeout(1000 * 10);
 const [slotName, decoderName] = ['slot_decoderbufs', 'decoderbufs'];

--- a/src/test/decoder-pgoutput.spec.ts
+++ b/src/test/decoder-pgoutput.spec.ts
@@ -1,7 +1,7 @@
-import { LogicalReplicationService } from '../logical-replication-service';
-import { TestClientConfig } from './client-config';
-import { Pgoutput, PgoutputPlugin } from '../output-plugins/pgoutput';
-import { TestClient } from './test-common';
+import { LogicalReplicationService } from '../logical-replication-service.js';
+import { Pgoutput, PgoutputPlugin } from '../output-plugins/pgoutput/index.js';
+import { TestClientConfig } from './client-config.js';
+import { TestClient } from './test-common.js';
 
 jest.setTimeout(100_000);
 const [slotName, decoderName, publicationName] = ['slot_pgoutput', 'pgoutput', 'pgoutput_test_pub'];

--- a/src/test/decoder-test.spec.ts
+++ b/src/test/decoder-test.spec.ts
@@ -1,10 +1,10 @@
 /*
 SELECT * FROM pg_create_logical_replication_slot('slot_test_decoding', 'test_decoding');
 */
-import { LogicalReplicationService } from '../logical-replication-service';
-import { TestClientConfig } from './client-config';
-import { TestDecodingPlugin } from '../output-plugins/test_decoding/test-decoding-plugin';
-import { sleep, TestClient } from './test-common';
+import { LogicalReplicationService } from '../logical-replication-service.js';
+import { TestDecodingPlugin } from '../output-plugins/test_decoding/test-decoding-plugin.js';
+import { TestClientConfig } from './client-config.js';
+import { sleep, TestClient } from './test-common.js';
 
 jest.setTimeout(1000 * 10);
 const [slotName, decoderName] = ['slot_test_decoding', 'test_decoding'];

--- a/src/test/decoder-wal2json.spec.ts
+++ b/src/test/decoder-wal2json.spec.ts
@@ -1,11 +1,11 @@
 /*
 SELECT * FROM pg_create_logical_replication_slot('slot_wal2json', 'wal2json');
 */
-import { LogicalReplicationService } from '../logical-replication-service';
-import { TestClientConfig } from './client-config';
-import { Wal2JsonPlugin } from '../output-plugins/wal2json/wal2json-plugin';
-import { Wal2Json } from '../output-plugins/wal2json/wal2json-plugin-output.type';
-import { sleep, TestClient } from './test-common';
+import { LogicalReplicationService } from '../logical-replication-service.js';
+import { Wal2Json } from '../output-plugins/wal2json/wal2json-plugin-output.type.js';
+import { Wal2JsonPlugin } from '../output-plugins/wal2json/wal2json-plugin.js';
+import { TestClientConfig } from './client-config.js';
+import { sleep, TestClient } from './test-common.js';
 
 jest.setTimeout(1000 * 30);
 const [slotName, decoderName] = ['slot_wal2json', 'wal2json'];

--- a/src/test/test-common.ts
+++ b/src/test/test-common.ts
@@ -1,5 +1,5 @@
 import { Client } from 'pg';
-import { TestClientConfig } from './client-config';
+import { TestClientConfig } from './client-config.js';
 
 export class TestClient extends Client {
   private constructor(public readonly slotName: string, public readonly decoderName: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,10 +28,10 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",
+    "module": "Node16",
     /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "Node16"                         /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
This is mostly to unblock `@cloudflare/vitest-worker-pool` which has a bug that prevents it from resolving `dir/a/b` to `dir/a/b/index.js`.

https://github.com/cloudflare/workers-sdk/pull/5749#issuecomment-2091812981