### PR TITLE
feat: "messages" pgoutput option to receive messages from pg_logical_emit_message()

### DIFF
--- a/src/output-plugins/pgoutput/pgoutput-plugin.ts
+++ b/src/output-plugins/pgoutput/pgoutput-plugin.ts
@@ -25,6 +25,7 @@ export class PgoutputPlugin extends AbstractPlugin<Options> {
     const options = [
       `proto_version '${this.options.protoVersion}'`,
       `publication_names '${this.options.publicationNames.join(',')}'`,
+      `messages '${this.options.messages ?? false}'`,
     ];
 
     const sql = `START_REPLICATION SLOT "${slotName}" LOGICAL ${lastLsn} (${options.join(', ')})`;

--- a/src/output-plugins/pgoutput/pgoutput.types.ts
+++ b/src/output-plugins/pgoutput/pgoutput.types.ts
@@ -2,6 +2,7 @@
 export interface Options {
   protoVersion: 1 | 2
   publicationNames: string[]
+  messages?: boolean
 }
 
 export type Message =


### PR DESCRIPTION
Allows setting of the `messages` option in `pgoutput` starting parameters to enable receipt of messages outputted by `pg_logical_emit_message`.

Reference: https://www.postgresql.org/docs/current/protocol-logical-replication.html#PROTOCOL-LOGICAL-REPLICATION-PARAMS

Closes #35 