### PR TITLE
feat: option to ping server in acknowledge

### DIFF
--- a/src/logical-replication-service.ts
+++ b/src/logical-replication-service.ts
@@ -168,8 +168,9 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
 
   /**
    * @param lsn
+   * @param ping Request server to respond
    */
-  public async acknowledge(lsn: string): Promise<boolean> {
+  public async acknowledge(lsn: string, ping: boolean = false): Promise<boolean> {
     if (this._stop) return false;
     this.lastStandbyStatusUpdatedTime = Date.now();
 
@@ -209,7 +210,7 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
     response.writeUInt32BE(lowerTimestamp, 29);
 
     // If 1, requests server to respond immediately - can be used to verify connectivity
-    response.writeInt8(0, 33);
+    response.writeInt8(ping ? 1 : 0, 33);
 
     // @ts-ignore
     this._connection?.sendCopyFromChunk(response);


### PR DESCRIPTION
This comes in handy for checking if the server / replication is still allive. 

Without it, it's trickier to rely on the keep alive messages from the server to check that the replication connection is ok. Postgres server sends keep alive messages automatically but when and how often it sends them depends on a number of things. 
Being able to ping the server, makes things easier. 