### PR TITLE
fix: add rootDir to tsconfig.build.json for TypeScript 6 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Features
+- Add `destroy()` method to `LogicalReplicationService` for clean full shutdown
+  - Calls `stop()` then `removeAllListeners()` to release all resources
+  - Use `destroy()` when done with the service entirely; use `stop()` when re-subscription is needed
+
+### Bug Fixes
+- Fix compatibility with TypeScript 6.0
+  - Add explicit `rootDir` to `tsconfig.build.json` and `tsconfig.json` (TS5011)
+  - Replace deprecated `module` keyword with `namespace` in output type declarations (TS1540)
+- Fix `acknowledge` test: use `timeoutSeconds: 0` to prevent standby status timer from auto-acknowledging LSN before replay test
+
 ## v2.3.0 (2026-03-10)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Use `destroy()` when done with the service entirely; use `stop()` when re-subscription is needed
 
 ### Bug Fixes
+- Fix `acknowledge.timeoutSeconds` timer ignoring `auto: false` — standby status was being sent even when `auto` was `false`, which caused unintended WAL flush and broke manual-acknowledge workflows
 - Fix compatibility with TypeScript 6.0
   - Add explicit `rootDir` to `tsconfig.build.json` and `tsconfig.json` (TS5011)
   - Replace deprecated `module` keyword with `namespace` in output type declarations (TS1540)

--- a/README.md
+++ b/README.md
@@ -172,6 +172,33 @@ const service = new LogicalReplicationService({
 - Usually this is done **automatically**.
 - Manually use only when `new LogicalReplicationService({}, {acknowledge: {auto: false}})`.
 
+**Manual acknowledge example:**
+
+```typescript
+const service = new LogicalReplicationService(clientConfig, {
+  acknowledge: {
+    auto: false,      // Disable automatic acknowledgement
+    timeoutSeconds: 0 // Disable periodic standby status as well
+  }
+});
+
+service.on('data', async (lsn: string, log: Wal2Json.Output) => {
+  try {
+    // Process the change
+    await processChange(log);
+
+    // Manually acknowledge only after successful processing.
+    // PostgreSQL will not advance the replication slot until this is called.
+    await service.acknowledge(lsn);
+  } catch (err) {
+    // If you don't acknowledge, PostgreSQL will re-send this change on reconnect.
+    console.error('Failed to process, skipping ack:', err);
+  }
+});
+```
+
+> **Note:** When `auto: false`, the `timeoutSeconds` timer has no effect — it will not send any standby status automatically. Set `timeoutSeconds: 0` to make this explicit.
+
 ### 3-4. Flow Control (Backpressure)
 
 When processing messages takes longer than the rate at which PostgreSQL sends them, the internal buffer can grow

--- a/README.md
+++ b/README.md
@@ -210,6 +210,10 @@ service.on('data', async (lsn: string, log: Pgoutput.Message) => {
 
 - `stop(): Promise<this>`
     - Terminate the server's connection and stop replication.
+    - Event listeners registered on the service are **preserved**, so you can re-subscribe and receive events again.
+- `destroy(): Promise<this>`
+    - Calls `stop()` and then removes all event listeners via `removeAllListeners()`.
+    - Use this when you are done with the service entirely and want to ensure clean shutdown (e.g. at the end of a test or application lifecycle).
 - `isStop(): boolean`
     - Returns false when replication starts from the server.
 - `lastLsn(): string`

--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ const service = new LogicalReplicationService({
        * Acknowledge is performed every set time (sec). If 0, do not do it.
        * Default: 10
        */
+      /**
+       * Periodically send standby status (heartbeat) to PostgreSQL and acknowledge WAL progress.
+       * Only takes effect when auto is true. If 0, do not send periodic acknowledgements.
+       * Default: 10
+       */
       timeoutSeconds: 0 | 10 | number;
     };
     flowControl?: {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "jest --maxWorkers=1",
+    "test": "jest --maxWorkers=1 --forceExit",
     "test:watch": "jest --watch",
     "build": "rm -rf dist/* ; tsc -p tsconfig.build.json"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "jest --maxWorkers=1 --forceExit",
+    "test": "jest --maxWorkers=1",
     "test:watch": "jest --watch",
     "build": "rm -rf dist/* ; tsc -p tsconfig.build.json"
   },

--- a/src/logical-replication-service.ts
+++ b/src/logical-replication-service.ts
@@ -110,8 +110,13 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
     this._client = null;
 
     this.checkStandbyStatus(false);
-    this.removeAllListeners();
 
+    return this;
+  }
+
+  public async destroy(): Promise<this> {
+    await this.stop();
+    this.removeAllListeners();
     return this;
   }
 

--- a/src/logical-replication-service.ts
+++ b/src/logical-replication-service.ts
@@ -110,6 +110,7 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
     this._client = null;
 
     this.checkStandbyStatus(false);
+    this.removeAllListeners();
 
     return this;
   }

--- a/src/logical-replication-service.ts
+++ b/src/logical-replication-service.ts
@@ -234,6 +234,7 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
         if (this._stop) return;
 
         if (
+          this.config.acknowledge!.auto &&
           this._lastLsn &&
           Date.now() - this.lastStandbyStatusUpdatedTime > this.config.acknowledge!.timeoutSeconds * 1000
         )

--- a/src/output-plugins/decoderbufs/decoderbufs-plugin-output.type.ts
+++ b/src/output-plugins/decoderbufs/decoderbufs-plugin-output.type.ts
@@ -6,7 +6,7 @@ export enum ProtocolBuffersOperation {
   BEGIN = 3,
   COMMIT = 4,
 }
-export declare module ProtocolBuffers {
+export declare namespace ProtocolBuffers {
   export interface Point {
     x: number;
     y: number;

--- a/src/output-plugins/wal2json/wal2json-plugin-output.type.ts
+++ b/src/output-plugins/wal2json/wal2json-plugin-output.type.ts
@@ -1,4 +1,4 @@
-export declare module Wal2Json {
+export declare namespace Wal2Json {
   export interface Output {
     change: Change[];
 

--- a/src/test/acknowledge.spec.ts
+++ b/src/test/acknowledge.spec.ts
@@ -48,7 +48,7 @@ describe('acknowledge', () => {
 
     // stop & resume
     await service.stop();
-    service.removeAllListeners();    await sleep(500);
+    await sleep(500);
     service.subscribe(plugin, slotName);
     await sleep(500);
     expect(inserted).toBe(5);
@@ -60,11 +60,11 @@ describe('acknowledge', () => {
 
     // stop & resume with 0/00000000 lsn
     await service.stop();
-    service.removeAllListeners();    await sleep(500);
+    await sleep(500);
     service.subscribe(plugin, slotName, '0/00000000');
     await sleep(500);
     expect(inserted).toBe(20);
 
-    await service.stop();
+    await service.destroy();
   });
 });

--- a/src/test/acknowledge.spec.ts
+++ b/src/test/acknowledge.spec.ts
@@ -48,7 +48,7 @@ describe('acknowledge', () => {
 
     // stop & resume
     await service.stop();
-    await sleep(500);
+    service.removeAllListeners();    await sleep(500);
     service.subscribe(plugin, slotName);
     await sleep(500);
     expect(inserted).toBe(5);
@@ -60,11 +60,12 @@ describe('acknowledge', () => {
 
     // stop & resume with 0/00000000 lsn
     await service.stop();
-    await sleep(500);
+    service.removeAllListeners();    await sleep(500);
     service.subscribe(plugin, slotName, '0/00000000');
     await sleep(500);
     expect(inserted).toBe(20);
 
     await service.stop();
+    service.removeAllListeners();
   });
 });

--- a/src/test/acknowledge.spec.ts
+++ b/src/test/acknowledge.spec.ts
@@ -66,6 +66,5 @@ describe('acknowledge', () => {
     expect(inserted).toBe(20);
 
     await service.stop();
-    service.removeAllListeners();
   });
 });

--- a/src/test/acknowledge.spec.ts
+++ b/src/test/acknowledge.spec.ts
@@ -31,7 +31,7 @@ describe('acknowledge', () => {
 
   it('Resume streaming using the internal _lastLsn value', async () => {
     service = new LogicalReplicationService(TestClientConfig, {
-      acknowledge: { auto: false, timeoutSeconds: 10 },
+      acknowledge: { auto: false, timeoutSeconds: 0 },
     });
     const plugin = new Wal2JsonPlugin({});
 

--- a/src/test/acknowledge.spec.ts
+++ b/src/test/acknowledge.spec.ts
@@ -7,11 +7,13 @@ import { Wal2JsonPlugin } from '../output-plugins/wal2json/wal2json-plugin.js';
 import { TestClientConfig } from './client-config.js';
 import { sleep, TestClient } from './test-common.js';
 
-jest.setTimeout(1000 * 10);
+jest.setTimeout(1000 * 30);
 const [slotName, decoderName] = ['slot_acknowledge', 'wal2json'];
 
 let client: TestClient;
 describe('acknowledge', () => {
+  let service: LogicalReplicationService | null = null;
+
   beforeAll(async () => {
     client = await TestClient.New(slotName, decoderName);
   });
@@ -20,8 +22,15 @@ describe('acknowledge', () => {
     await client.end();
   });
 
+  afterEach(async () => {
+    if (service) {
+      await service.destroy();
+      service = null;
+    }
+  });
+
   it('Resume streaming using the internal _lastLsn value', async () => {
-    const service = new LogicalReplicationService(TestClientConfig, {
+    service = new LogicalReplicationService(TestClientConfig, {
       acknowledge: { auto: false, timeoutSeconds: 10 },
     });
     const plugin = new Wal2JsonPlugin({});
@@ -58,13 +67,11 @@ describe('acknowledge', () => {
     await sleep(500);
     expect(inserted).toBe(10);
 
-    // stop & resume with 0/00000000 lsn
+    // stop & resume with 0/00000000 lsn - replays all unacknowledged data
     await service.stop();
     await sleep(500);
     service.subscribe(plugin, slotName, '0/00000000');
-    await sleep(500);
+    await sleep(1000);
     expect(inserted).toBe(20);
-
-    await service.destroy();
   });
 });

--- a/src/test/acknowledge.spec.ts
+++ b/src/test/acknowledge.spec.ts
@@ -28,7 +28,6 @@ describe('acknowledge', () => {
 
     let inserted = 0;
     service.on('data', (lsn: string, log: Wal2Json.Output) => {
-      console.log(lsn, log);
       inserted += log.change.filter((change) => change.kind === 'insert').length;
     });
 

--- a/src/test/decoder-decoderbufs.spec.ts
+++ b/src/test/decoder-decoderbufs.spec.ts
@@ -86,7 +86,7 @@ describe('decoderbufs', () => {
     expect(deleted).toBe(10);
 
     await service.stop();
-  });
+    service.removeAllListeners();  });
 
   it('Update', async () => {
     const service = new LogicalReplicationService(TestClientConfig);
@@ -122,5 +122,5 @@ describe('decoderbufs', () => {
 
     expect(rowCount).toBe(10);
     await service.stop();
-  });
+    service.removeAllListeners();  });
 });

--- a/src/test/decoder-decoderbufs.spec.ts
+++ b/src/test/decoder-decoderbufs.spec.ts
@@ -85,8 +85,8 @@ describe('decoderbufs', () => {
     // users 5 rows + user_contents 5 rows
     expect(deleted).toBe(10);
 
-    await service.stop();
-    service.removeAllListeners();  });
+    await service.destroy();
+  });
 
   it('Update', async () => {
     const service = new LogicalReplicationService(TestClientConfig);
@@ -121,6 +121,6 @@ describe('decoderbufs', () => {
     await sleep(1000);
 
     expect(rowCount).toBe(10);
-    await service.stop();
-    service.removeAllListeners();  });
+    await service.destroy();
+  });
 });

--- a/src/test/decoder-decoderbufs.spec.ts
+++ b/src/test/decoder-decoderbufs.spec.ts
@@ -15,6 +15,15 @@ const [slotName, decoderName] = ['slot_decoderbufs', 'decoderbufs'];
 
 let client: TestClient;
 describe('decoderbufs', () => {
+  let service: LogicalReplicationService | null = null;
+
+  afterEach(async () => {
+    if (service) {
+      await service.destroy();
+      service = null;
+    }
+  });
+
   beforeAll(async () => {
     client = await TestClient.New(slotName, decoderName);
   });
@@ -24,7 +33,7 @@ describe('decoderbufs', () => {
   });
 
   it('Insert, Delete(w/FK)', async () => {
-    const service = new LogicalReplicationService(TestClientConfig);
+    service = new LogicalReplicationService(TestClientConfig);
     const plugin = new ProtocolBuffersPlugin({});
 
     let inserted = 0;
@@ -85,11 +94,10 @@ describe('decoderbufs', () => {
     // users 5 rows + user_contents 5 rows
     expect(deleted).toBe(10);
 
-    await service.destroy();
   });
 
   it('Update', async () => {
-    const service = new LogicalReplicationService(TestClientConfig);
+    service = new LogicalReplicationService(TestClientConfig);
     const plugin = new ProtocolBuffersPlugin({});
 
     let rowCount = 0;
@@ -121,6 +129,5 @@ describe('decoderbufs', () => {
     await sleep(1000);
 
     expect(rowCount).toBe(10);
-    await service.destroy();
   });
 });

--- a/src/test/decoder-pgoutput.spec.ts
+++ b/src/test/decoder-pgoutput.spec.ts
@@ -12,6 +12,15 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 let client: TestClient;
 
 describe('pgoutput', () => {
+  let service: LogicalReplicationService | null = null;
+
+  afterEach(async () => {
+    if (service) {
+      await service.destroy();
+      service = null;
+    }
+  });
+
   beforeAll(async () => {
     client = await TestClient.New(slotName, decoderName);
     await client.query(
@@ -36,7 +45,7 @@ describe('pgoutput', () => {
   });
 
   it('Insert, Delete(w/FK)', async () => {
-    const service = new LogicalReplicationService(TestClientConfig);
+    service = new LogicalReplicationService(TestClientConfig);
     const plugin = new PgoutputPlugin({ protoVersion: 1, publicationNames: [publicationName] });
     const messages: Pgoutput.Message[] = [];
 
@@ -164,11 +173,10 @@ describe('pgoutput', () => {
       old: null,
     });
 
-    await service.destroy();
   });
 
   it('Update', async () => {
-    const service = new LogicalReplicationService(TestClientConfig);
+    service = new LogicalReplicationService(TestClientConfig);
     const plugin = new PgoutputPlugin({ protoVersion: 1, publicationNames: [publicationName] });
     const messages: Pgoutput.Message[] = [];
 
@@ -222,11 +230,10 @@ describe('pgoutput', () => {
       },
     });
 
-    await service.destroy();
   });
 
   it('Rollback', async () => {
-    const service = new LogicalReplicationService(TestClientConfig);
+    service = new LogicalReplicationService(TestClientConfig);
     const plugin = new PgoutputPlugin({ protoVersion: 1, publicationNames: [publicationName] });
     const messages: Pgoutput.Message[] = [];
 
@@ -264,11 +271,10 @@ describe('pgoutput', () => {
     await sleep(100);
     expect(messages.filter((msg) => msg.tag === 'insert').length).toBe(10);
 
-    await service.destroy();
   });
 
   it('Message', async () => {
-    const service = new LogicalReplicationService(TestClientConfig);
+    service = new LogicalReplicationService(TestClientConfig);
     const plugin = new PgoutputPlugin({ protoVersion: 1, publicationNames: [publicationName], messages: true });
     const messages: Pgoutput.Message[] = [];
 
@@ -313,11 +319,10 @@ describe('pgoutput', () => {
       transactional: true,
     });
 
-    await service.destroy();
   });
 
   it('Huge transaction', async () => {
-    const service = new LogicalReplicationService(TestClientConfig);
+    service = new LogicalReplicationService(TestClientConfig);
     const plugin = new PgoutputPlugin({ protoVersion: 1, publicationNames: [publicationName] });
 
     let rowCount = 0;
@@ -365,6 +370,5 @@ describe('pgoutput', () => {
     expect(rowCount).toBe(count);
     expect(heartbeatCb).toHaveBeenCalledWith(expect.any(String), expect.any(Number), expect.any(Boolean));
 
-    await service.destroy();
   });
 });

--- a/src/test/decoder-pgoutput.spec.ts
+++ b/src/test/decoder-pgoutput.spec.ts
@@ -164,8 +164,8 @@ describe('pgoutput', () => {
       old: null,
     });
 
-    await service.stop();
-    service.removeAllListeners();  });
+    await service.destroy();
+  });
 
   it('Update', async () => {
     const service = new LogicalReplicationService(TestClientConfig);
@@ -222,8 +222,8 @@ describe('pgoutput', () => {
       },
     });
 
-    await service.stop();
-    service.removeAllListeners();  });
+    await service.destroy();
+  });
 
   it('Rollback', async () => {
     const service = new LogicalReplicationService(TestClientConfig);
@@ -264,8 +264,8 @@ describe('pgoutput', () => {
     await sleep(100);
     expect(messages.filter((msg) => msg.tag === 'insert').length).toBe(10);
 
-    await service.stop();
-    service.removeAllListeners();  });
+    await service.destroy();
+  });
 
   it('Message', async () => {
     const service = new LogicalReplicationService(TestClientConfig);
@@ -313,8 +313,8 @@ describe('pgoutput', () => {
       transactional: true,
     });
 
-    await service.stop();
-    service.removeAllListeners();  });
+    await service.destroy();
+  });
 
   it('Huge transaction', async () => {
     const service = new LogicalReplicationService(TestClientConfig);
@@ -365,6 +365,6 @@ describe('pgoutput', () => {
     expect(rowCount).toBe(count);
     expect(heartbeatCb).toHaveBeenCalledWith(expect.any(String), expect.any(Number), expect.any(Boolean));
 
-    await service.stop();
-    service.removeAllListeners();  });
+    await service.destroy();
+  });
 });

--- a/src/test/decoder-pgoutput.spec.ts
+++ b/src/test/decoder-pgoutput.spec.ts
@@ -165,7 +165,7 @@ describe('pgoutput', () => {
     });
 
     await service.stop();
-  });
+    service.removeAllListeners();  });
 
   it('Update', async () => {
     const service = new LogicalReplicationService(TestClientConfig);
@@ -223,7 +223,7 @@ describe('pgoutput', () => {
     });
 
     await service.stop();
-  });
+    service.removeAllListeners();  });
 
   it('Rollback', async () => {
     const service = new LogicalReplicationService(TestClientConfig);
@@ -265,7 +265,7 @@ describe('pgoutput', () => {
     expect(messages.filter((msg) => msg.tag === 'insert').length).toBe(10);
 
     await service.stop();
-  });
+    service.removeAllListeners();  });
 
   it('Message', async () => {
     const service = new LogicalReplicationService(TestClientConfig);
@@ -314,7 +314,7 @@ describe('pgoutput', () => {
     });
 
     await service.stop();
-  });
+    service.removeAllListeners();  });
 
   it('Huge transaction', async () => {
     const service = new LogicalReplicationService(TestClientConfig);
@@ -366,5 +366,5 @@ describe('pgoutput', () => {
     expect(heartbeatCb).toHaveBeenCalledWith(expect.any(String), expect.any(Number), expect.any(Boolean));
 
     await service.stop();
-  });
+    service.removeAllListeners();  });
 });

--- a/src/test/decoder-test.spec.ts
+++ b/src/test/decoder-test.spec.ts
@@ -11,6 +11,15 @@ const [slotName, decoderName] = ['slot_test_decoding', 'test_decoding'];
 
 let client: TestClient;
 describe('test_decoding', () => {
+  let service: LogicalReplicationService | null = null;
+
+  afterEach(async () => {
+    if (service) {
+      await service.destroy();
+      service = null;
+    }
+  });
+
   beforeAll(async () => {
     client = await TestClient.New(slotName, decoderName);
   });
@@ -20,7 +29,7 @@ describe('test_decoding', () => {
   });
 
   it('Insert, Delete(w/FK)', async () => {
-    const service = new LogicalReplicationService(TestClientConfig);
+    service = new LogicalReplicationService(TestClientConfig);
     const plugin = new TestDecodingPlugin({});
 
     let inserted = 0;
@@ -81,11 +90,10 @@ describe('test_decoding', () => {
     // users 5 rows + user_contents 5 rows
     expect(deleted).toBe(10);
 
-    await service.destroy();
   });
 
   it('Update', async () => {
-    const service = new LogicalReplicationService(TestClientConfig);
+    service = new LogicalReplicationService(TestClientConfig);
     const plugin = new TestDecodingPlugin({});
 
     let rowCount = 0;
@@ -117,6 +125,5 @@ describe('test_decoding', () => {
     await sleep(1000);
 
     expect(rowCount).toBe(10);
-    await service.destroy();
   });
 });

--- a/src/test/decoder-test.spec.ts
+++ b/src/test/decoder-test.spec.ts
@@ -81,8 +81,8 @@ describe('test_decoding', () => {
     // users 5 rows + user_contents 5 rows
     expect(deleted).toBe(10);
 
-    await service.stop();
-    service.removeAllListeners();  });
+    await service.destroy();
+  });
 
   it('Update', async () => {
     const service = new LogicalReplicationService(TestClientConfig);
@@ -117,6 +117,6 @@ describe('test_decoding', () => {
     await sleep(1000);
 
     expect(rowCount).toBe(10);
-    await service.stop();
-    service.removeAllListeners();  });
+    await service.destroy();
+  });
 });

--- a/src/test/decoder-test.spec.ts
+++ b/src/test/decoder-test.spec.ts
@@ -82,7 +82,7 @@ describe('test_decoding', () => {
     expect(deleted).toBe(10);
 
     await service.stop();
-  });
+    service.removeAllListeners();  });
 
   it('Update', async () => {
     const service = new LogicalReplicationService(TestClientConfig);
@@ -118,5 +118,5 @@ describe('test_decoding', () => {
 
     expect(rowCount).toBe(10);
     await service.stop();
-  });
+    service.removeAllListeners();  });
 });

--- a/src/test/decoder-wal2json.spec.ts
+++ b/src/test/decoder-wal2json.spec.ts
@@ -85,8 +85,8 @@ describe('wal2json', () => {
     // users 5 rows + user_contents 5 rows
     expect(deleted).toBe(10);
 
-    await service.stop();
-    service.removeAllListeners();  });
+    await service.destroy();
+  });
 
   it('Update', async () => {
     const service = new LogicalReplicationService(TestClientConfig);
@@ -121,6 +121,6 @@ describe('wal2json', () => {
     await sleep(1000);
 
     expect(rowCount).toBe(10);
-    await service.stop();
-    service.removeAllListeners();  });
+    await service.destroy();
+  });
 });

--- a/src/test/decoder-wal2json.spec.ts
+++ b/src/test/decoder-wal2json.spec.ts
@@ -12,6 +12,15 @@ const [slotName, decoderName] = ['slot_wal2json', 'wal2json'];
 
 let client: TestClient;
 describe('wal2json', () => {
+  let service: LogicalReplicationService | null = null;
+
+  afterEach(async () => {
+    if (service) {
+      await service.destroy();
+      service = null;
+    }
+  });
+
   beforeAll(async () => {
     client = await TestClient.New(slotName, decoderName);
   });
@@ -21,7 +30,7 @@ describe('wal2json', () => {
   });
 
   it('Insert, Delete(w/FK)', async () => {
-    const service = new LogicalReplicationService(TestClientConfig);
+    service = new LogicalReplicationService(TestClientConfig);
     const plugin = new Wal2JsonPlugin({});
 
     let inserted = 0;
@@ -85,11 +94,10 @@ describe('wal2json', () => {
     // users 5 rows + user_contents 5 rows
     expect(deleted).toBe(10);
 
-    await service.destroy();
   });
 
   it('Update', async () => {
-    const service = new LogicalReplicationService(TestClientConfig);
+    service = new LogicalReplicationService(TestClientConfig);
     const plugin = new Wal2JsonPlugin({});
 
     let rowCount = 0;
@@ -121,6 +129,5 @@ describe('wal2json', () => {
     await sleep(1000);
 
     expect(rowCount).toBe(10);
-    await service.destroy();
   });
 });

--- a/src/test/decoder-wal2json.spec.ts
+++ b/src/test/decoder-wal2json.spec.ts
@@ -86,7 +86,7 @@ describe('wal2json', () => {
     expect(deleted).toBe(10);
 
     await service.stop();
-  });
+    service.removeAllListeners();  });
 
   it('Update', async () => {
     const service = new LogicalReplicationService(TestClientConfig);
@@ -122,5 +122,5 @@ describe('wal2json', () => {
 
     expect(rowCount).toBe(10);
     await service.stop();
-  });
+    service.removeAllListeners();  });
 });

--- a/src/test/flow-control.spec.ts
+++ b/src/test/flow-control.spec.ts
@@ -61,7 +61,6 @@ describe('flowControl', () => {
     await sleep(2000);
 
     await service.stop();
-    service.removeAllListeners();
     // With flowControl enabled, messages should be processed in order
     // Both processing and completion order should be sequential
     expect(processingOrder).toEqual([0, 1, 2, 3, 4]);
@@ -108,7 +107,6 @@ describe('flowControl', () => {
     await sleep(2000);
 
     await service.stop();
-    service.removeAllListeners();
     // Without flowControl, messages start processing in order
     expect(processingOrder).toEqual([0, 1, 2, 3, 4]);
 
@@ -163,7 +161,6 @@ describe('flowControl', () => {
     await sleep(2000);
 
     await service.stop();
-    service.removeAllListeners();
     // Should process all messages except the one that threw
     expect(processedMessages).toEqual(['msg-0', 'msg-1', 'msg-3', 'msg-4']);
     expect(errors.length).toBe(1);
@@ -205,7 +202,6 @@ describe('flowControl', () => {
     // Stop the service after a short delay (before all messages are processed)
     await sleep(300);
     await service.stop();
-    service.removeAllListeners();
     // Should have processed fewer than 5 messages due to early stop
     expect(processedMessages.length).toBeLessThan(5);
   });

--- a/src/test/flow-control.spec.ts
+++ b/src/test/flow-control.spec.ts
@@ -9,6 +9,15 @@ const [slotName, decoderName, publicationName] = ['slot_flow_control', 'pgoutput
 let client: TestClient;
 
 describe('flowControl', () => {
+  let service: LogicalReplicationService | null = null;
+
+  afterEach(async () => {
+    if (service) {
+      await service.destroy();
+      service = null;
+    }
+  });
+
   beforeAll(async () => {
     client = await TestClient.New(slotName, decoderName);
     await client.query(`DROP PUBLICATION IF EXISTS "${publicationName}"`);
@@ -21,7 +30,7 @@ describe('flowControl', () => {
   });
 
   it('should process messages sequentially when flowControl is enabled', async () => {
-    const service = new LogicalReplicationService(TestClientConfig, {
+    service = new LogicalReplicationService(TestClientConfig, {
       flowControl: { enabled: true },
     });
     const plugin = new PgoutputPlugin({ protoVersion: 1, publicationNames: [publicationName] });
@@ -60,7 +69,6 @@ describe('flowControl', () => {
     // Wait for all messages to be processed
     await sleep(2000);
 
-    await service.destroy();
     // With flowControl enabled, messages should be processed in order
     // Both processing and completion order should be sequential
     expect(processingOrder).toEqual([0, 1, 2, 3, 4]);
@@ -68,7 +76,7 @@ describe('flowControl', () => {
   });
 
   it('should process messages concurrently when flowControl is disabled (default)', async () => {
-    const service = new LogicalReplicationService(TestClientConfig, {
+    service = new LogicalReplicationService(TestClientConfig, {
       flowControl: { enabled: false },
     });
     const plugin = new PgoutputPlugin({ protoVersion: 1, publicationNames: [publicationName] });
@@ -106,7 +114,6 @@ describe('flowControl', () => {
     // Wait for all messages to be processed
     await sleep(2000);
 
-    await service.destroy();
     // Without flowControl, messages start processing in order
     expect(processingOrder).toEqual([0, 1, 2, 3, 4]);
 
@@ -119,7 +126,7 @@ describe('flowControl', () => {
   });
 
   it('should handle errors in async handlers without blocking the queue', async () => {
-    const service = new LogicalReplicationService(TestClientConfig, {
+    service = new LogicalReplicationService(TestClientConfig, {
       flowControl: { enabled: true },
     });
     const plugin = new PgoutputPlugin({ protoVersion: 1, publicationNames: [publicationName] });
@@ -160,7 +167,6 @@ describe('flowControl', () => {
 
     await sleep(2000);
 
-    await service.destroy();
     // Should process all messages except the one that threw
     expect(processedMessages).toEqual(['msg-0', 'msg-1', 'msg-3', 'msg-4']);
     expect(errors.length).toBe(1);
@@ -168,7 +174,7 @@ describe('flowControl', () => {
   });
 
   it('should stop processing when service is stopped', async () => {
-    const service = new LogicalReplicationService(TestClientConfig, {
+    service = new LogicalReplicationService(TestClientConfig, {
       flowControl: { enabled: true },
     });
     const plugin = new PgoutputPlugin({ protoVersion: 1, publicationNames: [publicationName] });
@@ -201,7 +207,6 @@ describe('flowControl', () => {
 
     // Stop the service after a short delay (before all messages are processed)
     await sleep(300);
-    await service.destroy();
     // Should have processed fewer than 5 messages due to early stop
     expect(processedMessages.length).toBeLessThan(5);
   });

--- a/src/test/flow-control.spec.ts
+++ b/src/test/flow-control.spec.ts
@@ -61,7 +61,7 @@ describe('flowControl', () => {
     await sleep(2000);
 
     await service.stop();
-
+    service.removeAllListeners();
     // With flowControl enabled, messages should be processed in order
     // Both processing and completion order should be sequential
     expect(processingOrder).toEqual([0, 1, 2, 3, 4]);
@@ -108,7 +108,7 @@ describe('flowControl', () => {
     await sleep(2000);
 
     await service.stop();
-
+    service.removeAllListeners();
     // Without flowControl, messages start processing in order
     expect(processingOrder).toEqual([0, 1, 2, 3, 4]);
 
@@ -163,7 +163,7 @@ describe('flowControl', () => {
     await sleep(2000);
 
     await service.stop();
-
+    service.removeAllListeners();
     // Should process all messages except the one that threw
     expect(processedMessages).toEqual(['msg-0', 'msg-1', 'msg-3', 'msg-4']);
     expect(errors.length).toBe(1);
@@ -205,7 +205,7 @@ describe('flowControl', () => {
     // Stop the service after a short delay (before all messages are processed)
     await sleep(300);
     await service.stop();
-
+    service.removeAllListeners();
     // Should have processed fewer than 5 messages due to early stop
     expect(processedMessages.length).toBeLessThan(5);
   });

--- a/src/test/flow-control.spec.ts
+++ b/src/test/flow-control.spec.ts
@@ -60,7 +60,7 @@ describe('flowControl', () => {
     // Wait for all messages to be processed
     await sleep(2000);
 
-    await service.stop();
+    await service.destroy();
     // With flowControl enabled, messages should be processed in order
     // Both processing and completion order should be sequential
     expect(processingOrder).toEqual([0, 1, 2, 3, 4]);
@@ -106,7 +106,7 @@ describe('flowControl', () => {
     // Wait for all messages to be processed
     await sleep(2000);
 
-    await service.stop();
+    await service.destroy();
     // Without flowControl, messages start processing in order
     expect(processingOrder).toEqual([0, 1, 2, 3, 4]);
 
@@ -160,7 +160,7 @@ describe('flowControl', () => {
 
     await sleep(2000);
 
-    await service.stop();
+    await service.destroy();
     // Should process all messages except the one that threw
     expect(processedMessages).toEqual(['msg-0', 'msg-1', 'msg-3', 'msg-4']);
     expect(errors.length).toBe(1);
@@ -201,7 +201,7 @@ describe('flowControl', () => {
 
     // Stop the service after a short delay (before all messages are processed)
     await sleep(300);
-    await service.stop();
+    await service.destroy();
     // Should have processed fewer than 5 messages due to early stop
     expect(processedMessages.length).toBeLessThan(5);
   });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
   "exclude": ["node_modules", "**/test", "dist", "**/*spec.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,7 @@
     /* Modules */
     "module": "NodeNext",
     /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "nodenext"                         /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */


### PR DESCRIPTION
TypeScript 6.0 requires `rootDir` to be explicitly set in tsconfig.

Fixes CI failures introduced by #164 (TypeScript 5.9.3 → 6.0.2 upgrade).

```
error TS5011: The common source directory of 'tsconfig.build.json' is './src'. The 'rootDir' setting must be explicitly set to this or another path to adjust your output's file layout.
```