### PR TITLE
ci: release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v3.0.0 (2026-04-14)
 
 ### Features
 - Add `destroy()` method to `LogicalReplicationService` for clean full shutdown

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-logical-replication",
-  "version": "2.3.1",
+  "version": "3.0.0",
   "description": "PostgreSQL Location Replication client - logical WAL replication streaming",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -39,7 +39,7 @@
   },
   "contributors": [
     {
-      "name": "Jón Tómas Grétarsson",
+      "name": "J\u00f3n T\u00f3mas Gr\u00e9tarsson",
       "email": "jon.gretarsson@gmail.com",
       "url": "https://github.com/jontg"
     },


### PR DESCRIPTION
## v3.0.0

### ⚠️ Breaking Changes
- `acknowledge.timeoutSeconds` timer no longer sends automatic ACK when `auto: false`. Previously, the standby status timer called `acknowledge()` regardless of the `auto` setting, causing unintended WAL flush in manual-acknowledge mode.

### Features
- Add `destroy()` method for clean full shutdown (`stop()` + `removeAllListeners()`)
  - Use `stop()` when re-subscription is needed; use `destroy()` when done with the service entirely

### Bug Fixes
- Fix `auto: false` + `timeoutSeconds > 0` sending unintended ACK to PostgreSQL
- Fix TypeScript 6.0 compatibility (TS5011: explicit `rootDir` required, TS1540: `namespace` keyword)
- Fix `acknowledge` test: `timeoutSeconds: 0` to prevent standby timer from interfering with replay

### Dependencies
- bump typescript 5.9.3 → 6.0.2
- bump @types/node 25.5.2 → 25.6.0
- bump prettier 3.8.1 → 3.8.2