### PR TITLE
ci: release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
   - Use `destroy()` when done with the service entirely; use `stop()` when re-subscription is needed
 
 ### Bug Fixes
-- Fix `acknowledge.timeoutSeconds` timer ignoring `auto: false` — standby status was being sent even when `auto` was `false`, which caused unintended WAL flush and broke manual-acknowledge workflows
 - Fix compatibility with TypeScript 6.0
   - Add explicit `rootDir` to `tsconfig.build.json` and `tsconfig.json` (TS5011)
   - Replace deprecated `module` keyword with `namespace` in output type declarations (TS1540)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v3.0.0 (2026-04-14)
+## v2.4.0 (2026-04-15)
 
 ### Features
 - Add `destroy()` method to `LogicalReplicationService` for clean full shutdown
@@ -11,7 +11,7 @@
 - Fix compatibility with TypeScript 6.0
   - Add explicit `rootDir` to `tsconfig.build.json` and `tsconfig.json` (TS5011)
   - Replace deprecated `module` keyword with `namespace` in output type declarations (TS1540)
-- Fix `acknowledge` test: use `timeoutSeconds: 0` to prevent standby status timer from auto-acknowledging LSN before replay test
+- Fix `acknowledge` test: use `timeoutSeconds: 0` to prevent standby status keepalive from interfering with replay assertions
 
 ## v2.3.0 (2026-03-10)
 

--- a/README.md
+++ b/README.md
@@ -138,11 +138,6 @@ const service = new LogicalReplicationService({
        * Acknowledge is performed every set time (sec). If 0, do not do it.
        * Default: 10
        */
-      /**
-       * Periodically send standby status (heartbeat) to PostgreSQL and acknowledge WAL progress.
-       * Only takes effect when auto is true. If 0, do not send periodic acknowledgements.
-       * Default: 10
-       */
       timeoutSeconds: 0 | 10 | number;
     };
     flowControl?: {

--- a/README.md
+++ b/README.md
@@ -135,8 +135,9 @@ const service = new LogicalReplicationService({
        */
       auto: boolean;
       /**
-       * Acknowledge is performed every set time (sec). If 0, do not do it.
-       * Default: 10
+       * Periodically sends standby status (keepalive) to PostgreSQL.
+       * When auto is true, also advances the WAL flush position.
+       * Set to 0 to disable. Default: 10
        */
       timeoutSeconds: 0 | 10 | number;
     };
@@ -192,7 +193,7 @@ service.on('data', async (lsn: string, log: Wal2Json.Output) => {
 });
 ```
 
-> **Note:** When `auto: false`, the `timeoutSeconds` timer has no effect — it will not send any standby status automatically. Set `timeoutSeconds: 0` to make this explicit.
+> **Note:** When `auto: false`, `timeoutSeconds` still sends periodic standby status (keepalive) to PostgreSQL to maintain the connection, but does **not** advance the WAL flush position. Set `timeoutSeconds: 0` to disable keepalive entirely.
 
 ### 3-4. Flow Control (Backpressure)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-logical-replication",
-  "version": "3.0.0",
+  "version": "2.4.0",
   "description": "PostgreSQL Location Replication client - logical WAL replication streaming",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/logical-replication-service.ts
+++ b/src/logical-replication-service.ts
@@ -234,7 +234,6 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
         if (this._stop) return;
 
         if (
-          this.config.acknowledge!.auto &&
           this._lastLsn &&
           Date.now() - this.lastStandbyStatusUpdatedTime > this.config.acknowledge!.timeoutSeconds * 1000
         )


### PR DESCRIPTION
## Changes

- Revert accidental breaking change: `timeoutSeconds` timer now correctly sends keepalive even when `auto: false`
- Clarify `timeoutSeconds` docs: it sends periodic standby status (keepalive) regardless of `auto`; when `auto: true`, it also advances WAL flush position

### Included in this release
- `destroy()` method for clean full shutdown
- TypeScript 6.0 compatibility fixes
- Test cleanup with `afterEach` + `destroy()`