### PR TITLE
feat!: split acknowledge config into autoAck + keepaliveIntervalSeconds (v3.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## v3.0.1 (2026-04-22)
+
+### Breaking Changes
+- Replace nested `acknowledge: { auto, timeoutSeconds }` with top-level `autoAck` and `keepaliveIntervalSeconds`
+  - The old shape conflated two independent concerns (auto-ack on data messages vs. periodic keepalive), which silently advanced the replication slot when `auto: false` was set — see #174
+  - The deprecated `acknowledge` key is still accepted for one major version and mapped to the new keys with a `console.warn`; it will be removed in 4.0
+
+### Bug Fixes
+- The periodic keepalive timer no longer silently advances `confirmed_flush_lsn` when `autoAck: false`
+  - Received LSN and acknowledged LSN are now tracked separately internally
+  - The keepalive continues to run (so `wal_sender_timeout` does not drop the connection) but only reports the manually acknowledged position as flushed/applied
+
+### Migration
+
+Before (v2.x):
+```ts
+new LogicalReplicationService(clientConfig, {
+  acknowledge: { auto: false, timeoutSeconds: 10 },
+});
+```
+
+After (v3.0.1):
+```ts
+new LogicalReplicationService(clientConfig, {
+  autoAck: false,
+  keepaliveIntervalSeconds: 10,
+});
+```
+
 ## v2.4.0 (2026-04-15)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # pg-logical-replication
 
+> ### ⚠️ Breaking Change in v3.0.1 — `acknowledge` config replaced
+>
+> The nested `acknowledge: { auto, timeoutSeconds }` option has been split into two top-level keys:
+> `autoAck` and `keepaliveIntervalSeconds`. The old shape silently advanced the replication slot
+> when `auto: false` was set ([#174](https://github.com/kibae/pg-logical-replication/issues/174)).
+>
+> ```diff
+> - new LogicalReplicationService(clientConfig, {
+> -   acknowledge: { auto: false, timeoutSeconds: 10 },
+> - });
+> + new LogicalReplicationService(clientConfig, {
+> +   autoAck: false,
+> +   keepaliveIntervalSeconds: 10,
+> + });
+> ```
+>
+> The old `acknowledge` key is still accepted in v3.x with a deprecation warning and will be
+> removed in v4.0. See the [CHANGELOG](./CHANGELOG.md#v301-2026-04-22) for full details.
+
 - [PostgreSQL Logical Replication](https://www.postgresql.org/docs/current/logical-replication.html) client for node.js(
   `>=16.9.0`)
 - Supported plugins
@@ -54,10 +73,8 @@ const service = new LogicalReplicationService(
    * https://github.com/kibae/pg-logical-replication/blob/main/src/logical-replication-service.ts#L9
    */
   {
-    acknowledge: {
-      auto: true,
-      timeoutSeconds: 10
-    }
+    autoAck: true,
+    keepaliveIntervalSeconds: 10
   }
 )
 
@@ -127,20 +144,21 @@ const service = new LogicalReplicationService({
    * Logical replication service config
    * https://github.com/kibae/pg-logical-replication/blob/main/src/logical-replication-service.ts#L9
    */
-  config? : Partial<{
-    acknowledge?: {
-      /**
-       * If the value is false, acknowledge must be done manually.
-       * Default: true
-       */
-      auto: boolean;
-      /**
-       * Periodically sends standby status (keepalive) to PostgreSQL.
-       * When auto is true, also advances the WAL flush position.
-       * Set to 0 to disable. Default: 10
-       */
-      timeoutSeconds: 0 | 10 | number;
-    };
+  config? : {
+    /**
+     * Send ack after every data message (advances the slot automatically).
+     * If false, the caller must invoke `acknowledge()` manually.
+     * Default: true
+     */
+    autoAck?: boolean;
+    /**
+     * Keepalive interval (seconds) for the periodic standby status update.
+     * Works independently of `autoAck`: when autoAck is false, the keepalive
+     * keeps the connection alive but does NOT advance the flush position past
+     * the last manually acknowledged LSN. Set to 0 to disable.
+     * Default: 10
+     */
+    keepaliveIntervalSeconds?: number;
     flowControl?: {
       /**
        * If true, pause the stream until the data handler completes.
@@ -149,7 +167,11 @@ const service = new LogicalReplicationService({
        */
       enabled: boolean;
     };
-  }>
+    /**
+     * @deprecated Use `autoAck` / `keepaliveIntervalSeconds`. Will be removed in 4.0.
+     */
+    acknowledge?: { auto?: boolean; timeoutSeconds?: number };
+  }
 })
 ```
 
@@ -166,16 +188,14 @@ const service = new LogicalReplicationService({
 
 - After processing the data, it signals the PostgreSQL server that it is OK to clear the WAL log.
 - Usually this is done **automatically**.
-- Manually use only when `new LogicalReplicationService({}, {acknowledge: {auto: false}})`.
+- Manually use only when `new LogicalReplicationService({}, { autoAck: false })`.
 
 **Manual acknowledge example:**
 
 ```typescript
 const service = new LogicalReplicationService(clientConfig, {
-  acknowledge: {
-    auto: false,      // Disable automatic acknowledgement
-    timeoutSeconds: 0 // Disable periodic standby status as well
-  }
+  autoAck: false,               // Disable automatic acknowledgement
+  keepaliveIntervalSeconds: 10  // Keep the connection alive; does NOT advance the slot
 });
 
 service.on('data', async (lsn: string, log: Wal2Json.Output) => {
@@ -193,7 +213,7 @@ service.on('data', async (lsn: string, log: Wal2Json.Output) => {
 });
 ```
 
-> **Note:** When `auto: false`, `timeoutSeconds` still sends periodic standby status (keepalive) to PostgreSQL to maintain the connection, but does **not** advance the WAL flush position. Set `timeoutSeconds: 0` to disable keepalive entirely.
+> **Note:** When `autoAck: false`, the `keepaliveIntervalSeconds` timer still sends periodic standby status to PostgreSQL to keep the connection alive, but it reports only the last **manually acknowledged** LSN as the flush position — so the replication slot never silently advances past unacknowledged work. Set `keepaliveIntervalSeconds: 0` to disable the keepalive entirely.
 
 ### 3-4. Flow Control (Backpressure)
 
@@ -202,7 +222,8 @@ indefinitely, leading to memory issues (OOM). The `flowControl` option enables b
 
 ```typescript
 const service = new LogicalReplicationService(clientConfig, {
-  acknowledge: { auto: true, timeoutSeconds: 10 },
+  autoAck: true,
+  keepaliveIntervalSeconds: 10,
   flowControl: { enabled: true }  // Enable backpressure support
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-logical-replication",
-  "version": "2.4.0",
+  "version": "3.0.1",
   "description": "PostgreSQL Location Replication client - logical WAL replication streaming",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/logical-replication-service.ts
+++ b/src/logical-replication-service.ts
@@ -7,18 +7,22 @@ export interface ReplicationClientConfig extends ClientConfig {
 }
 
 export interface LogicalReplicationConfig {
-  acknowledge?: {
-    /**
-     * If the value is false, acknowledge must be done manually.
-     * Default: true
-     */
-    auto: boolean;
-    /**
-     * Acknowledge is performed every set time (sec). If 0, do not do it.
-     * Default: 10
-     */
-    timeoutSeconds: 0 | 10 | number;
-  };
+  /**
+   * If true, send an acknowledgment after every data message so the replication
+   * slot advances automatically. If false, the caller must invoke `acknowledge()`
+   * manually — the keepalive timer will still run but will NOT advance the slot
+   * past the last manually acknowledged LSN.
+   * Default: true
+   */
+  autoAck?: boolean;
+  /**
+   * Interval (in seconds) for sending a standby status update to keep the
+   * replication connection alive. Set to 0 to disable the periodic keepalive.
+   * The keepalive uses the last acknowledged LSN for flush/apply positions,
+   * so it never silently advances the slot past unacknowledged work.
+   * Default: 10
+   */
+  keepaliveIntervalSeconds?: number;
   /**
    * Flow control (backpressure) configuration.
    * When enabled, the stream will be paused until the data handler completes,
@@ -32,6 +36,20 @@ export interface LogicalReplicationConfig {
      */
     enabled: boolean;
   };
+  /**
+   * @deprecated Use `autoAck` and `keepaliveIntervalSeconds` at the top level.
+   * Will be removed in 4.0. If supplied, values are mapped with a console warning.
+   */
+  acknowledge?: {
+    auto?: boolean;
+    timeoutSeconds?: number;
+  };
+}
+
+interface NormalizedConfig {
+  autoAck: boolean;
+  keepaliveIntervalSeconds: number;
+  flowControl: { enabled: boolean };
 }
 
 export interface LogicalReplicationService {
@@ -46,15 +64,35 @@ export interface LogicalReplicationService {
 }
 
 export class LogicalReplicationService extends EventEmitter2 implements LogicalReplicationService {
-  public readonly config: LogicalReplicationConfig;
-  constructor(public readonly clientConfig: ClientConfig, config?: Partial<LogicalReplicationConfig>) {
+  public readonly config: NormalizedConfig;
+  constructor(public readonly clientConfig: ClientConfig, config?: LogicalReplicationConfig) {
     super();
-    this.config = {
-      acknowledge: {
-        auto: true,
-        timeoutSeconds: 10,
-        ...(config?.acknowledge || {}),
-      },
+    this.config = LogicalReplicationService.normalizeConfig(config);
+  }
+
+  private static normalizeConfig(config?: LogicalReplicationConfig): NormalizedConfig {
+    let autoAck = config?.autoAck ?? true;
+    let keepaliveIntervalSeconds = config?.keepaliveIntervalSeconds ?? 10;
+
+    if (config?.acknowledge !== undefined) {
+      console.warn(
+        '[pg-logical-replication] `acknowledge` config is deprecated and will be removed in 4.0. ' +
+          'Use top-level `autoAck` and `keepaliveIntervalSeconds` instead.'
+      );
+      if (config.autoAck === undefined && config.acknowledge.auto !== undefined) {
+        autoAck = config.acknowledge.auto;
+      }
+      if (
+        config.keepaliveIntervalSeconds === undefined &&
+        config.acknowledge.timeoutSeconds !== undefined
+      ) {
+        keepaliveIntervalSeconds = config.acknowledge.timeoutSeconds;
+      }
+    }
+
+    return {
+      autoAck,
+      keepaliveIntervalSeconds,
       flowControl: {
         enabled: false,
         ...(config?.flowControl || {}),
@@ -62,9 +100,10 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
     };
   }
 
-  private _lastLsn: string | null = null;
+  private _lastReceivedLsn: string | null = null;
+  private _lastAckedLsn: string | null = null;
   public lastLsn(): string {
-    return this._lastLsn || '0/00000000';
+    return this._lastReceivedLsn || '0/00000000';
   }
 
   private _client: Client | null = null;
@@ -134,7 +173,10 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
   async subscribe(plugin: AbstractPlugin, slotName: string, uptoLsn?: string): Promise<this> {
     try {
       const [client, connection] = await this.client();
-      this._lastLsn = uptoLsn || this._lastLsn;
+      this._lastReceivedLsn = uptoLsn || this._lastReceivedLsn;
+      // Seed the acked LSN floor from the starting position so keepalives
+      // never send a flushed value lower than what the slot already holds.
+      this._lastAckedLsn = this._lastReceivedLsn;
 
       // check replicationStart
       connection.once('replicationStart', () => {
@@ -170,10 +212,10 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
           const shouldRespond = !!buffer.readInt8(17);
           this.emit('heartbeat', lsn, timestamp, shouldRespond);
         }
-        this._lastLsn = lsn;
+        this._lastReceivedLsn = lsn;
       });
 
-      return plugin.start(client, slotName, this._lastLsn || '0/00000000').catch(e => {
+      return plugin.start(client, slotName, this._lastReceivedLsn || '0/00000000').catch(e => {
         if (!this._stop || !/Connection\s+terminated/i.test(e?.toString()))
           throw e;
       });
@@ -185,7 +227,7 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
   }
 
   private async _acknowledge(lsn: string) {
-    if (!this.config.acknowledge!.auto) return;
+    if (!this.config.autoAck) return;
 
     this.emit('acknowledge', lsn);
     await this.acknowledge(lsn);
@@ -235,56 +277,63 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
       clearInterval(this.checkStandbyStatusTimer);
       this.checkStandbyStatusTimer = null;
     }
-    if (this.config.acknowledge!.timeoutSeconds > 0 && enable)
+    if (this.config.keepaliveIntervalSeconds > 0 && enable)
       this.checkStandbyStatusTimer = setInterval(async () => {
         if (this._stop) return;
 
         if (
-          this._lastLsn &&
-          Date.now() - this.lastStandbyStatusUpdatedTime > this.config.acknowledge!.timeoutSeconds * 1000
-        )
-          await this.acknowledge(this._lastLsn);
+          this._lastAckedLsn &&
+          Date.now() - this.lastStandbyStatusUpdatedTime > this.config.keepaliveIntervalSeconds * 1000
+        ) {
+          // Keepalive only — never advances the slot past manually acked LSN.
+          // The received position may be ahead; the flush/apply position stays
+          // at _lastAckedLsn so the server does not discard unacked WAL.
+          await this.sendStandbyStatus(this._lastReceivedLsn ?? this._lastAckedLsn, this._lastAckedLsn, false);
+        }
       }, 1000);
   }
 
   /**
+   * Manually acknowledge an LSN. Advances the replication slot up to `lsn`.
    * @param lsn
    * @param ping Request server to respond
    */
   public async acknowledge(lsn: string, ping: boolean = false): Promise<boolean> {
     if (this._stop) return false;
+    this._lastAckedLsn = lsn;
+    return this.sendStandbyStatus(lsn, lsn, ping);
+  }
+
+  private async sendStandbyStatus(
+    receivedLsn: string,
+    flushedLsn: string,
+    ping: boolean
+  ): Promise<boolean> {
+    if (this._stop) return false;
     this.lastStandbyStatusUpdatedTime = Date.now();
 
-    const slice = lsn.split('/');
-    let [upperWAL, lowerWAL]: [number, number] = [parseInt(slice[0], 16), parseInt(slice[1], 16)];
+    const [receivedUpper, receivedLower] = bumpLsn(receivedLsn);
+    const [flushedUpper, flushedLower] = bumpLsn(flushedLsn);
 
     // Timestamp as microseconds since midnight 2000-01-01
     const now = Date.now() - 946080000000;
     const upperTimestamp = Math.floor(now / 4294967.296);
     const lowerTimestamp = Math.floor(now - upperTimestamp * 4294967.296);
 
-    if (lowerWAL === 4294967295) {
-      // [0xff, 0xff, 0xff, 0xff]
-      upperWAL = upperWAL + 1;
-      lowerWAL = 0;
-    } else {
-      lowerWAL = lowerWAL + 1;
-    }
-
     const response = Buffer.alloc(34);
     response.fill(0x72); // 'r'
 
     // Last WAL Byte + 1 received and written to disk locally
-    response.writeUInt32BE(upperWAL, 1);
-    response.writeUInt32BE(lowerWAL, 5);
+    response.writeUInt32BE(receivedUpper, 1);
+    response.writeUInt32BE(receivedLower, 5);
 
     // Last WAL Byte + 1 flushed to disk in the standby
-    response.writeUInt32BE(upperWAL, 9);
-    response.writeUInt32BE(lowerWAL, 13);
+    response.writeUInt32BE(flushedUpper, 9);
+    response.writeUInt32BE(flushedLower, 13);
 
     // Last WAL Byte + 1 applied in the standby
-    response.writeUInt32BE(upperWAL, 17);
-    response.writeUInt32BE(lowerWAL, 21);
+    response.writeUInt32BE(flushedUpper, 17);
+    response.writeUInt32BE(flushedLower, 21);
 
     // Timestamp as microseconds since midnight 2000-01-01
     response.writeUInt32BE(upperTimestamp, 25);
@@ -298,4 +347,20 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
 
     return true;
   }
+}
+
+function bumpLsn(lsn: string): [number, number] {
+  const slice = lsn.split('/');
+  let upper = parseInt(slice[0], 16);
+  let lower = parseInt(slice[1], 16);
+
+  if (lower === 4294967295) {
+    // [0xff, 0xff, 0xff, 0xff]
+    upper = upper + 1;
+    lower = 0;
+  } else {
+    lower = lower + 1;
+  }
+
+  return [upper, lower];
 }

--- a/src/logical-replication-service.ts
+++ b/src/logical-replication-service.ts
@@ -202,7 +202,9 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
           } else {
             // Original behavior: emit immediately
             this.emit('data', lsn, plugin.parse(buffer.subarray(25)));
-            this._acknowledge(lsn);
+            this._acknowledge(lsn).catch((error) => {
+              this.emit('error', error);
+            });
           }
         } else if (buffer[0] == 0x6b) {
           // Primary keepalive message
@@ -278,7 +280,7 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
       this.checkStandbyStatusTimer = null;
     }
     if (this.config.keepaliveIntervalSeconds > 0 && enable)
-      this.checkStandbyStatusTimer = setInterval(async () => {
+      this.checkStandbyStatusTimer = setInterval(() => {
         if (this._stop) return;
 
         if (
@@ -288,7 +290,11 @@ export class LogicalReplicationService extends EventEmitter2 implements LogicalR
           // Keepalive only — never advances the slot past manually acked LSN.
           // The received position may be ahead; the flush/apply position stays
           // at _lastAckedLsn so the server does not discard unacked WAL.
-          await this.sendStandbyStatus(this._lastReceivedLsn ?? this._lastAckedLsn, this._lastAckedLsn, false);
+          this.sendStandbyStatus(this._lastReceivedLsn ?? this._lastAckedLsn, this._lastAckedLsn, false).catch(
+            (error) => {
+              this.emit('error', error);
+            }
+          );
         }
       }, 1000);
   }

--- a/src/test/acknowledge.spec.ts
+++ b/src/test/acknowledge.spec.ts
@@ -29,9 +29,10 @@ describe('acknowledge', () => {
     }
   });
 
-  it('Resume streaming using the internal _lastLsn value', async () => {
+  it('Resume streaming using the internal last-received LSN value', async () => {
     service = new LogicalReplicationService(TestClientConfig, {
-      acknowledge: { auto: false, timeoutSeconds: 0 },
+      autoAck: false,
+      keepaliveIntervalSeconds: 0,
     });
     const plugin = new Wal2JsonPlugin({});
 

--- a/src/test/async-handler-fix.spec.ts
+++ b/src/test/async-handler-fix.spec.ts
@@ -1,0 +1,96 @@
+import { LogicalReplicationService } from '../logical-replication-service.js';
+import { Wal2JsonPlugin } from '../output-plugins/wal2json/wal2json-plugin.js';
+import { TestClientConfig } from './client-config.js';
+import { sleep, TestClient } from './test-common.js';
+
+jest.setTimeout(30_000);
+const [slotName, decoderName] = ['slot_async_handler_fix', 'wal2json'];
+
+let client: TestClient;
+
+describe('async handler error propagation (issue #62)', () => {
+  let service: LogicalReplicationService | null = null;
+  const unhandledRejections: unknown[] = [];
+  const unhandledRejectionHandler = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+
+  beforeAll(async () => {
+    client = await TestClient.New(slotName, decoderName);
+  });
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  beforeEach(() => {
+    unhandledRejections.length = 0;
+    process.on('unhandledRejection', unhandledRejectionHandler);
+  });
+
+  afterEach(async () => {
+    process.off('unhandledRejection', unhandledRejectionHandler);
+    if (service) {
+      await service.destroy();
+      service = null;
+    }
+  });
+
+  it('routes acknowledge failures from the data path to the error event', async () => {
+    service = new LogicalReplicationService(TestClientConfig, { autoAck: true });
+    const plugin = new Wal2JsonPlugin({});
+
+    const errors: Error[] = [];
+    service.on('error', (err: Error) => errors.push(err));
+
+    service.subscribe(plugin, slotName).catch(() => {});
+    await sleep(200);
+
+    // Override sendStandbyStatus so the fire-and-forget _acknowledge(lsn)
+    // rejects when a data message arrives.
+    (service as any).sendStandbyStatus = jest
+      .fn()
+      .mockRejectedValue(new Error('boom: data-path ack failure'));
+
+    await client.query(
+      //language=postgresql
+      `INSERT INTO users(firstname, lastname, email, phone)
+       SELECT md5(RANDOM()::TEXT), md5(RANDOM()::TEXT), md5(RANDOM()::TEXT), md5(RANDOM()::TEXT)
+       FROM generate_series(1, 1)`
+    );
+
+    await sleep(500);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toBe('boom: data-path ack failure');
+    expect(unhandledRejections).toEqual([]);
+  });
+
+  it('routes keepalive failures from the standby timer to the error event', async () => {
+    service = new LogicalReplicationService(TestClientConfig, {
+      autoAck: false,
+      keepaliveIntervalSeconds: 1,
+    });
+    const plugin = new Wal2JsonPlugin({});
+
+    const errors: Error[] = [];
+    service.on('error', (err: Error) => errors.push(err));
+
+    // Seed _lastAckedLsn via uptoLsn so the keepalive gate opens without
+    // needing a real data message.
+    service.subscribe(plugin, slotName, '0/00000000').catch(() => {});
+    await sleep(200);
+
+    (service as any).sendStandbyStatus = jest
+      .fn()
+      .mockRejectedValue(new Error('boom: keepalive failure'));
+
+    // Timer ticks every 1s; with keepaliveIntervalSeconds=1 the first tick
+    // already satisfies the elapsed-time gate.
+    await sleep(1500);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toBe('boom: keepalive failure');
+    expect(unhandledRejections).toEqual([]);
+  });
+});

--- a/src/test/config-normalize.spec.ts
+++ b/src/test/config-normalize.spec.ts
@@ -1,0 +1,52 @@
+import { LogicalReplicationService } from '../logical-replication-service.js';
+
+describe('config normalization', () => {
+  const dummyClientConfig = { host: 'localhost', user: 'none', database: 'none' };
+
+  let warnSpy: jest.SpyInstance;
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('applies defaults when no config is passed', () => {
+    const service = new LogicalReplicationService(dummyClientConfig);
+    expect(service.config.autoAck).toBe(true);
+    expect(service.config.keepaliveIntervalSeconds).toBe(10);
+    expect(service.config.flowControl.enabled).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('uses new top-level keys when provided', () => {
+    const service = new LogicalReplicationService(dummyClientConfig, {
+      autoAck: false,
+      keepaliveIntervalSeconds: 30,
+    });
+    expect(service.config.autoAck).toBe(false);
+    expect(service.config.keepaliveIntervalSeconds).toBe(30);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('maps deprecated `acknowledge` keys and emits a warning', () => {
+    const service = new LogicalReplicationService(dummyClientConfig, {
+      acknowledge: { auto: false, timeoutSeconds: 20 },
+    });
+    expect(service.config.autoAck).toBe(false);
+    expect(service.config.keepaliveIntervalSeconds).toBe(20);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/deprecated/);
+  });
+
+  it('prefers new keys over deprecated ones when both are supplied', () => {
+    const service = new LogicalReplicationService(dummyClientConfig, {
+      autoAck: true,
+      keepaliveIntervalSeconds: 5,
+      acknowledge: { auto: false, timeoutSeconds: 99 },
+    });
+    expect(service.config.autoAck).toBe(true);
+    expect(service.config.keepaliveIntervalSeconds).toBe(5);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
  ## Summary
  - Replace nested `acknowledge: { auto, timeoutSeconds }` with top-level `autoAck` and
  `keepaliveIntervalSeconds`. The old shape bundled two independent concerns — auto-ack on
   data messages vs. periodic keepalive — which caused the replication slot to silently
  advance past unacknowledged work when `auto: false` was set
  ([#174](https://github.com/kibae/pg-logical-replication/issues/174)).
  - Track received LSN and acknowledged LSN separately internally. The keepalive timer now
   reports only the last manually acknowledged LSN as the flushed/applied position, so
  `autoAck: false` users can rely on the slot staying put.
  - Deprecated `acknowledge` key is still accepted in v3.x with a `console.warn` and value
   mapping; scheduled for removal in v4.0.

  ## Migration

  ```diff
  - new LogicalReplicationService(clientConfig, {
  -   acknowledge: { auto: false, timeoutSeconds: 10 },
  - });
  + new LogicalReplicationService(clientConfig, {
  +   autoAck: false,
  +   keepaliveIntervalSeconds: 10,
  + });
  ```

  Prominent notice added at the top of `README.md`; full details in `CHANGELOG.md`.

  ## Test plan
  - [x] `npx tsc --noEmit` passes
  - [x] `jest config-normalize` — 4/4 unit tests pass (defaults, new keys, deprecated shim
   with warning, precedence when both supplied)
  - [x] Run full Jest suite against PostgreSQL 14/15/16/17/18 via CI
  - [x] Manually verify `autoAck: false, keepaliveIntervalSeconds: 10` keeps connection
  alive without advancing `pg_replication_slots.confirmed_flush_lsn`
  - [x] Manually verify deprecated `acknowledge: { auto, timeoutSeconds }` still works
  with warning

  Closes #174