### PR TITLE
Add Node.js 26 support, drop EOL Node 16/18 (v2.5.0)

### DIFF
--- a/.github/workflows/nodejs-pgsql14.yml
+++ b/.github/workflows/nodejs-pgsql14.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js(16,18,20,22,24) w/Postgres 14
+name: Node.js(20,22,24,26) w/Postgres 14
 
 on:
   push:
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, 18, 20, 22, 24]
+        node-version: [20, 22, 24, 26]
 
     services:
       postgres:
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/nodejs-pgsql15.yml
+++ b/.github/workflows/nodejs-pgsql15.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js(16,18,20,22,24) w/Postgres 15
+name: Node.js(20,22,24,26) w/Postgres 15
 
 on:
   push:
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, 18, 20, 22, 24]
+        node-version: [20, 22, 24, 26]
 
     services:
       postgres:
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/nodejs-pgsql16.yml
+++ b/.github/workflows/nodejs-pgsql16.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js(16,18,20,22,24) w/Postgres 16
+name: Node.js(20,22,24,26) w/Postgres 16
 
 on:
   push:
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, 18, 20, 22, 24]
+        node-version: [20, 22, 24, 26]
 
     services:
       postgres:
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/nodejs-pgsql17.yml
+++ b/.github/workflows/nodejs-pgsql17.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js(16,18,20,22,24) w/Postgres 17
+name: Node.js(20,22,24,26) w/Postgres 17
 
 on:
   push:
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, 18, 20, 22, 24]
+        node-version: [20, 22, 24, 26]
 
     services:
       postgres:
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/nodejs-pgsql18.yml
+++ b/.github/workflows/nodejs-pgsql18.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js(16,18,20,22,24) w/Postgres 18
+name: Node.js(20,22,24,26) w/Postgres 18
 
 on:
   push:
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, 18, 20, 22, 24]
+        node-version: [20, 22, 24, 26]
 
     services:
       postgres:
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v2.5.0 (2026-05-27)
+
+### Features
+- Add Node.js 26 support
+  - CI test matrix now runs on Node.js 20, 22, 24, 26 across PostgreSQL 14–18
+
+### Breaking Changes
+- Drop support for EOL Node.js 16 and 18; minimum supported version is now Node.js `>=20.0.0`
+  - `engines.node` bumped from `>=16.9.0` to `>=20.0.0`
+
+### CI
+- Bump `actions/setup-node` from v3 to v4 for reliable resolution of the latest Node.js releases
+
 ## v2.4.0 (2026-04-15)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pg-logical-replication
 
 - [PostgreSQL Logical Replication](https://www.postgresql.org/docs/current/logical-replication.html) client for node.js(
-  `>=16.9.0`)
+  `>=20.0.0`)
 - Supported plugins
     - [pgoutput](https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html) (Native to
       PostgreSQL, Recommended)
@@ -14,13 +14,13 @@
 [![NPM Version](https://badge.fury.io/js/pg-logical-replication.svg)](https://www.npmjs.com/package/pg-logical-replication)
 [![License](https://img.shields.io/github/license/kibae/pg-logical-replication)](https://github.com/kibae/pg-logical-replication/blob/main/LICENSE)
 
-| PostgreSQL Versions | on Node.js 16, 18, 20, 22, 24                                                                                                                                                                                                        |
+| PostgreSQL Versions | on Node.js 20, 22, 24, 26                                                                                                                                                                                                        |
 |---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| PostgreSQL 14       | [![Node.js(16, 18, 20, 22, 24) w/Postgres 14](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql14.yml/badge.svg)](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql14.yml) |
-| PostgreSQL 15       | [![Node.js(16, 18, 20, 22, 24) w/Postgres 15](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql15.yml/badge.svg)](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql15.yml) |
-| PostgreSQL 16       | [![Node.js(16, 18, 20, 22, 24) w/Postgres 16](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql16.yml/badge.svg)](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql16.yml) |
-| PostgreSQL 17       | [![Node.js(16, 18, 20, 22, 24) w/Postgres 17](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql17.yml/badge.svg)](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql17.yml) |
-| PostgreSQL 18       | [![Node.js(16, 18, 20, 22, 24) w/Postgres 18](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql18.yml/badge.svg)](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql18.yml) |
+| PostgreSQL 14       | [![Node.js(20, 22, 24, 26) w/Postgres 14](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql14.yml/badge.svg)](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql14.yml) |
+| PostgreSQL 15       | [![Node.js(20, 22, 24, 26) w/Postgres 15](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql15.yml/badge.svg)](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql15.yml) |
+| PostgreSQL 16       | [![Node.js(20, 22, 24, 26) w/Postgres 16](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql16.yml/badge.svg)](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql16.yml) |
+| PostgreSQL 17       | [![Node.js(20, 22, 24, 26) w/Postgres 17](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql17.yml/badge.svg)](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql17.yml) |
+| PostgreSQL 18       | [![Node.js(20, 22, 24, 26) w/Postgres 18](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql18.yml/badge.svg)](https://github.com/kibae/pg-logical-replication/actions/workflows/nodejs-pgsql18.yml) |
 
 ## 1. Install
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-logical-replication",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "PostgreSQL Location Replication client - logical WAL replication streaming",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -94,6 +94,6 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=16.9.0"
+    "node": ">=20.0.0"
   }
 }


### PR DESCRIPTION
## Summary
Prepares the v2.5.0 release by adding Node.js 26 to the supported/tested versions and dropping the EOL Node.js 16 and 18.

## Changes
- **CI matrix**: test on Node.js `20, 22, 24, 26` across PostgreSQL 14–18 (was `16, 18, 20, 22, 24`)
- **engines.node**: bump `>=16.9.0` → `>=20.0.0`
- **actions/setup-node**: bump `v3` → `v4` for reliable resolution of the latest Node.js releases
- **version**: `2.4.0` → `2.5.0`
- Update README badges/notes and CHANGELOG

## Notes
- Dropping EOL Node 16/18 raises the minimum runtime; documented under Breaking Changes in CHANGELOG.
- `npm run build` (tsc) passes locally. Full test suite runs in CI (requires PostgreSQL).