### PR TITLE
ci: switch npm publish to Trusted Publishing (OIDC) + release v2.5.0

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: github action
 
+    permissions:
+      id-token: write # required for npm Trusted Publishing (OIDC)
+      contents: write # required to push the version tag and create the release
+
     services:
       postgres:
         image: kibaes/postgres-logical-replication-dev:17
@@ -31,6 +35,10 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Update npm
+        # Trusted Publishing (OIDC) requires npm >= 11.5.1
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 
@@ -47,9 +55,8 @@ jobs:
         run: npm run build
 
       - name: Publish to NPM
+        # Authentication via OIDC Trusted Publishing; provenance is attached automatically.
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create tag
         run: |


### PR DESCRIPTION
## Summary
Switches the npm release workflow from token-based auth (`NPM_TOKEN`) to npm **Trusted Publishing** via GitHub Actions OIDC. Merging this PR with the `release` label also triggers the **v2.5.0** publish that was skipped on #191 (the release label was missing at merge time).

## Workflow changes (`npm-publish.yml`)
- Add `permissions: id-token: write` (OIDC token) and `contents: write` (tag/release push)
- Upgrade npm to latest — Trusted Publishing requires npm `>= 11.5.1` (Node 20 bundles npm 10.x)
- Drop `NODE_AUTH_TOKEN` / `NPM_TOKEN` from the publish step; auth + provenance now come from OIDC

## Prerequisite before merge
On npmjs.com, configure a **Trusted Publisher** for the `pg-logical-replication` package:
- Repository: `kibae/pg-logical-replication`
- Workflow filename: `npm-publish.yml`
- Environment: `github action` (matches `environment:` in the workflow)

Once the Trusted Publisher is set up, merging this PR (with the `release` label) will publish v2.5.0, push the `v2.5.0` tag, and create the GitHub Release.